### PR TITLE
cli: Indicate source of a layout when listing

### DIFF
--- a/cmd/d2/help.go
+++ b/cmd/d2/help.go
@@ -48,7 +48,13 @@ func shortLayoutHelp(ctx context.Context, ms *xmain.State) error {
 		return err
 	}
 	for _, p := range plugins {
-		pluginLines = append(pluginLines, p.Name+" - "+p.ShortHelp)
+		var l string
+		if p.Type == "bundled" {
+			l = fmt.Sprintf("%s (bundled) - %s", p.Name, p.ShortHelp)
+		} else {
+			l = fmt.Sprintf("%s (%s) - %s", p.Name, humanPath(p.Path), p.ShortHelp)
+		}
+		pluginLines = append(pluginLines, l)
 	}
 	fmt.Fprintf(ms.Stdout, `Available layout engines found:
 


### PR DESCRIPTION
Closes #15

```
$ d2 layout
Available layout engines found:

dagre (bundled) - The directed graph layout library Dagre
tala (~/.local/share/gopath/bin/d2plugin-tala) - Terrastruct's AutoLayout Approach
```

Not as clean but having the source clearly visible is good for
debugging.
