### PR TITLE
install: add callout to next steps in terminal display

### DIFF
--- a/ci/release/_install.sh
+++ b/ci/release/_install.sh
@@ -318,7 +318,7 @@ uninstall_standalone_d2() {
 
   if [ ! -e "$INSTALL_DIR/d2-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/d2-$INSTALLED_VERSION"
-    warn "d2 has been installed via some other installation method."
+    warn "d2 must have been installed via some other installation method."
     return 1
   fi
 
@@ -341,7 +341,7 @@ uninstall_standalone_tala() {
 
   if [ ! -e "$INSTALL_DIR/tala-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/tala-$INSTALLED_VERSION"
-    warn "tala has been installed via some other installation method."
+    warn "tala must have been installed via some other installation method."
     return 1
   fi
 

--- a/ci/release/_install.sh
+++ b/ci/release/_install.sh
@@ -318,7 +318,7 @@ uninstall_standalone_d2() {
 
   if [ ! -e "$INSTALL_DIR/d2-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/d2-$INSTALLED_VERSION"
-    warn "d2 have been installed via some other installation method."
+    warn "d2 has been installed via some other installation method."
     return 1
   fi
 
@@ -341,7 +341,7 @@ uninstall_standalone_tala() {
 
   if [ ! -e "$INSTALL_DIR/tala-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/tala-$INSTALLED_VERSION"
-    warn "tala have been installed via some other installation method."
+    warn "tala has been installed via some other installation method."
     return 1
   fi
 

--- a/ci/release/_install.sh
+++ b/ci/release/_install.sh
@@ -181,8 +181,14 @@ install() {
   if [ -n "${TALA-}" ]; then
     log "tala-$TALA_VERSION-$OS-$ARCH has been successfully installed into $PREFIX"
   fi
+  log "Rerun this install script with --uninstall to uninstall"
   if ! echo "$PATH" | grep -qF "$PREFIX/bin"; then
     logcat >&2 <<EOF
+
+%%%%%%%%%%%%%%%%%%%%%%%%%
+NEXT STEPS
+%%%%%%%%%%%%%%%%%%%%%%%%%
+
 Extend your \$PATH to use d2:
   export PATH=$PREFIX/bin:\$PATH
 Then run:
@@ -207,8 +213,11 @@ EOF
       log "  Run man d2plugin-tala for detailed docs."
     fi
   fi
+  logcat >&2 <<EOF
 
-  log "Rerun the install script with --uninstall to uninstall"
+Something not working? Please let us know:
+https://github.com/terrastruct/d2/issues/new
+EOF
 }
 
 install_d2() {

--- a/install.sh
+++ b/install.sh
@@ -752,7 +752,7 @@ uninstall_standalone_d2() {
 
   if [ ! -e "$INSTALL_DIR/d2-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/d2-$INSTALLED_VERSION"
-    warn "d2 has been installed via some other installation method."
+    warn "d2 must have been installed via some other installation method."
     return 1
   fi
 
@@ -775,7 +775,7 @@ uninstall_standalone_tala() {
 
   if [ ! -e "$INSTALL_DIR/tala-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/tala-$INSTALLED_VERSION"
-    warn "tala has been installed via some other installation method."
+    warn "tala must have been installed via some other installation method."
     return 1
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -186,7 +186,7 @@ This script needs to run the following command as root:
   $*
 Please install doas, sudo, or su.
 EOF
-    exit 1
+    return 1
   fi
 }
 
@@ -214,7 +214,7 @@ hide() {
     return
   fi
   cat "$out" >&2
-  exit "$code"
+  return "$code"
 }
 
 echo_dur() {
@@ -615,8 +615,14 @@ install() {
   if [ -n "${TALA-}" ]; then
     log "tala-$TALA_VERSION-$OS-$ARCH has been successfully installed into $PREFIX"
   fi
+  log "Rerun this install script with --uninstall to uninstall"
   if ! echo "$PATH" | grep -qF "$PREFIX/bin"; then
     logcat >&2 <<EOF
+
+%%%%%%%%%%%%%%%%%%%%%%%%%
+NEXT STEPS
+%%%%%%%%%%%%%%%%%%%%%%%%%
+
 Extend your \$PATH to use d2:
   export PATH=$PREFIX/bin:\$PATH
 Then run:
@@ -641,8 +647,11 @@ EOF
       log "  Run man d2plugin-tala for detailed docs."
     fi
   fi
+  logcat >&2 <<EOF
 
-  log "Rerun the install script with --uninstall to uninstall"
+Something not working? Please let us know:
+https://github.com/terrastruct/d2/issues/new
+EOF
 }
 
 install_d2() {

--- a/install.sh
+++ b/install.sh
@@ -752,7 +752,7 @@ uninstall_standalone_d2() {
 
   if [ ! -e "$INSTALL_DIR/d2-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/d2-$INSTALLED_VERSION"
-    warn "d2 have been installed via some other installation method."
+    warn "d2 has been installed via some other installation method."
     return 1
   fi
 
@@ -775,7 +775,7 @@ uninstall_standalone_tala() {
 
   if [ ! -e "$INSTALL_DIR/tala-$INSTALLED_VERSION" ]; then
     warn "missing standalone install release directory $INSTALL_DIR/tala-$INSTALLED_VERSION"
-    warn "tala have been installed via some other installation method."
+    warn "tala has been installed via some other installation method."
     return 1
   fi
 


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

@ejulio-ts missed that he had to do something after install, and I think it won't be uncommon for others to as well. This adds a little callout that should catch the majority of cases.

Also adds a link to report issue if something went wrong

## Before

<img width="1602" alt="Screen Shot 2022-11-17 at 11 24 10 AM" src="https://user-images.githubusercontent.com/3120367/202541167-58b8229f-19fe-4e66-adea-c4de76e56a11.png">

## After

<img width="1672" alt="Screen Shot 2022-11-17 at 11 30 53 AM" src="https://user-images.githubusercontent.com/3120367/202541202-d63dea0d-0120-409e-a21b-4fefd13af7f6.png">
