### PR TITLE
export: Encode SVG images before PNG export

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -10,4 +10,4 @@ For v0.0.99 we focused on X, Y and Z. Enjoy!
 
 #### Bugfixes 🔴
 
-- Fixes something or the other #9999
+- Fixes PNG exports with images #176

--- a/lib/png/generate_png.js
+++ b/lib/png/generate_png.js
@@ -26,7 +26,6 @@ async (imgString) => {
     const promises = [];
     for (const image of images) {
       const url = image.getAttribute("href");
-      // encode all images to base64
       try {
         const encodedImage = await asyncLoad(url);
         const promise = new Promise((resolve) => {

--- a/lib/png/generate_png.js
+++ b/lib/png/generate_png.js
@@ -1,12 +1,62 @@
 async (imgString) => {
+  const tempDiv = document.createElement("div")
+  tempDiv.innerHTML = imgString;
+
+  const asyncLoad = async (url) => {
+    const resp = await fetch(url);
+    if (resp.status !== 200) {
+      throw new Error("failed to fetch");
+    }
+    const blob = await resp.blob();
+    const f = new FileReader();
+    f.readAsDataURL(blob);
+    const promise = new Promise((resolve, reject) => {
+      f.addEventListener("load", () => {
+        resolve(f.result);
+      });
+      f.addEventListener("error", (e) => {
+        reject(e);
+      });
+    });
+    return promise;
+  };
+
+  const loadSVGImages = async () => {
+    const images = tempDiv.querySelectorAll("image");
+    const promises = [];
+    for (const image of images) {
+      const url = image.getAttribute("href");
+      // encode all images to base64
+      try {
+        const encodedImage = await asyncLoad(url);
+        const promise = new Promise((resolve) => {
+          const newImage = new Image();
+          newImage.src = encodedImage;
+          newImage.onload = () => {
+            image.href.baseVal = newImage.src;
+            resolve("done");
+          };
+        });
+        promises.push(promise);
+      } catch (e) {
+        if (e.message === "failed to fetch") {
+          continue;
+        }
+      }
+    }
+    return Promise.all(promises);
+  };
+
+  await loadSVGImages();
   const tempImg = new Image();
   const loadImage = () => {
+    const encodedString = "data:image/svg+xml;charset=utf-8;base64," + btoa(conversionDiv.innerHTML)
     return new Promise((resolve, reject) => {
       tempImg.onload = (event) => resolve(event.currentTarget);
       tempImg.onerror = () => {
         reject("error loading string as an image");
       };
-      tempImg.src = imgString;
+      tempImg.src = encodedString;
     });
   };
   const img = await loadImage();

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -74,8 +74,7 @@ var genPNGScript string
 const pngPrefix = "data:image/png;base64,"
 
 func ConvertSVG(ms *xmain.State, page playwright.Page, svg []byte) ([]byte, error) {
-	encodedSVG := base64.StdEncoding.EncodeToString(svg)
-	pngInterface, err := page.Evaluate(genPNGScript, "data:image/svg+xml;charset=utf-8;base64,"+encodedSVG)
+	pngInterface, err := page.Evaluate(genPNGScript, string(svg))
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate png: %w", err)
 	}


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
Copy the code to encode SVG images from our internal export script.
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
![out](https://user-images.githubusercontent.com/6413609/203653233-e877c019-8ff1-4873-9e2b-e7679d070b37.png)
