### PR TITLE
syntax: shape: sequence

### DIFF
--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -266,6 +266,8 @@ func (c *compiler) compileKey(obj *d2graph.Object, m *d2ast.Map, mk *d2ast.Key) 
 		}, unresolvedObj)
 	} else if obj.Parent == nil {
 		// Top level reserved key set on root.
+		c.compileAttributes(&obj.Attributes, mk)
+		c.applyScalar(&obj.Attributes, reserved, mk.Value.ScalarBox())
 		return
 	}
 

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -1501,6 +1501,26 @@ dst.id <-> src.dst_id
 				}
 			},
 		},
+		{
+			name: "basic_sequence",
+
+			text: `x: {
+  shape: sequence
+}
+`,
+			assertions: func(t *testing.T, g *d2graph.Graph) {
+				diff.AssertStringEq(t, "sequence", g.Objects[0].Attributes.Shape.Value)
+			},
+		},
+		{
+			name: "root_sequence",
+
+			text: `shape: sequence
+`,
+			assertions: func(t *testing.T, g *d2graph.Graph) {
+				diff.AssertStringEq(t, "sequence", g.Root.Attributes.Shape.Value)
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -1505,20 +1505,20 @@ dst.id <-> src.dst_id
 			name: "basic_sequence",
 
 			text: `x: {
-  shape: sequence
+  shape: sequence_diagram
 }
 `,
 			assertions: func(t *testing.T, g *d2graph.Graph) {
-				diff.AssertStringEq(t, "sequence", g.Objects[0].Attributes.Shape.Value)
+				diff.AssertStringEq(t, "sequence_diagram", g.Objects[0].Attributes.Shape.Value)
 			},
 		},
 		{
 			name: "root_sequence",
 
-			text: `shape: sequence
+			text: `shape: sequence_diagram
 `,
 			assertions: func(t *testing.T, g *d2graph.Graph) {
-				diff.AssertStringEq(t, "sequence", g.Root.Attributes.Shape.Value)
+				diff.AssertStringEq(t, "sequence_diagram", g.Root.Attributes.Shape.Value)
 			},
 		},
 	}

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -255,29 +255,29 @@ func NewPoint(x, y int) Point {
 }
 
 const (
-	ShapeRectangle     = "rectangle"
-	ShapeSquare        = "square"
-	ShapePage          = "page"
-	ShapeParallelogram = "parallelogram"
-	ShapeDocument      = "document"
-	ShapeCylinder      = "cylinder"
-	ShapeQueue         = "queue"
-	ShapePackage       = "package"
-	ShapeStep          = "step"
-	ShapeCallout       = "callout"
-	ShapeStoredData    = "stored_data"
-	ShapePerson        = "person"
-	ShapeDiamond       = "diamond"
-	ShapeOval          = "oval"
-	ShapeCircle        = "circle"
-	ShapeHexagon       = "hexagon"
-	ShapeCloud         = "cloud"
-	ShapeText          = "text"
-	ShapeCode          = "code"
-	ShapeClass         = "class"
-	ShapeSQLTable      = "sql_table"
-	ShapeImage         = "image"
-	ShapeSequence      = "sequence"
+	ShapeRectangle       = "rectangle"
+	ShapeSquare          = "square"
+	ShapePage            = "page"
+	ShapeParallelogram   = "parallelogram"
+	ShapeDocument        = "document"
+	ShapeCylinder        = "cylinder"
+	ShapeQueue           = "queue"
+	ShapePackage         = "package"
+	ShapeStep            = "step"
+	ShapeCallout         = "callout"
+	ShapeStoredData      = "stored_data"
+	ShapePerson          = "person"
+	ShapeDiamond         = "diamond"
+	ShapeOval            = "oval"
+	ShapeCircle          = "circle"
+	ShapeHexagon         = "hexagon"
+	ShapeCloud           = "cloud"
+	ShapeText            = "text"
+	ShapeCode            = "code"
+	ShapeClass           = "class"
+	ShapeSQLTable        = "sql_table"
+	ShapeImage           = "image"
+	ShapeSequenceDiagram = "sequence_diagram"
 )
 
 var Shapes = []string{
@@ -303,7 +303,7 @@ var Shapes = []string{
 	ShapeClass,
 	ShapeSQLTable,
 	ShapeImage,
-	ShapeSequence,
+	ShapeSequenceDiagram,
 }
 
 func IsShape(s string) bool {
@@ -347,30 +347,30 @@ func (text MText) GetColor(theme *d2themes.Theme, isItalic bool) string {
 }
 
 var DSL_SHAPE_TO_SHAPE_TYPE = map[string]string{
-	"":                 shape.SQUARE_TYPE,
-	ShapeRectangle:     shape.SQUARE_TYPE,
-	ShapeSquare:        shape.REAL_SQUARE_TYPE,
-	ShapePage:          shape.PAGE_TYPE,
-	ShapeParallelogram: shape.PARALLELOGRAM_TYPE,
-	ShapeDocument:      shape.DOCUMENT_TYPE,
-	ShapeCylinder:      shape.CYLINDER_TYPE,
-	ShapeQueue:         shape.QUEUE_TYPE,
-	ShapePackage:       shape.PACKAGE_TYPE,
-	ShapeStep:          shape.STEP_TYPE,
-	ShapeCallout:       shape.CALLOUT_TYPE,
-	ShapeStoredData:    shape.STORED_DATA_TYPE,
-	ShapePerson:        shape.PERSON_TYPE,
-	ShapeDiamond:       shape.DIAMOND_TYPE,
-	ShapeOval:          shape.OVAL_TYPE,
-	ShapeCircle:        shape.CIRCLE_TYPE,
-	ShapeHexagon:       shape.HEXAGON_TYPE,
-	ShapeCloud:         shape.CLOUD_TYPE,
-	ShapeText:          shape.TEXT_TYPE,
-	ShapeCode:          shape.CODE_TYPE,
-	ShapeClass:         shape.CLASS_TYPE,
-	ShapeSQLTable:      shape.TABLE_TYPE,
-	ShapeImage:         shape.IMAGE_TYPE,
-	ShapeSequence:      shape.SQUARE_TYPE,
+	"":                   shape.SQUARE_TYPE,
+	ShapeRectangle:       shape.SQUARE_TYPE,
+	ShapeSquare:          shape.REAL_SQUARE_TYPE,
+	ShapePage:            shape.PAGE_TYPE,
+	ShapeParallelogram:   shape.PARALLELOGRAM_TYPE,
+	ShapeDocument:        shape.DOCUMENT_TYPE,
+	ShapeCylinder:        shape.CYLINDER_TYPE,
+	ShapeQueue:           shape.QUEUE_TYPE,
+	ShapePackage:         shape.PACKAGE_TYPE,
+	ShapeStep:            shape.STEP_TYPE,
+	ShapeCallout:         shape.CALLOUT_TYPE,
+	ShapeStoredData:      shape.STORED_DATA_TYPE,
+	ShapePerson:          shape.PERSON_TYPE,
+	ShapeDiamond:         shape.DIAMOND_TYPE,
+	ShapeOval:            shape.OVAL_TYPE,
+	ShapeCircle:          shape.CIRCLE_TYPE,
+	ShapeHexagon:         shape.HEXAGON_TYPE,
+	ShapeCloud:           shape.CLOUD_TYPE,
+	ShapeText:            shape.TEXT_TYPE,
+	ShapeCode:            shape.CODE_TYPE,
+	ShapeClass:           shape.CLASS_TYPE,
+	ShapeSQLTable:        shape.TABLE_TYPE,
+	ShapeImage:           shape.IMAGE_TYPE,
+	ShapeSequenceDiagram: shape.SQUARE_TYPE,
 }
 
 var SHAPE_TYPE_TO_DSL_SHAPE map[string]string

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -277,6 +277,7 @@ const (
 	ShapeClass         = "class"
 	ShapeSQLTable      = "sql_table"
 	ShapeImage         = "image"
+	ShapeSequence      = "sequence"
 )
 
 var Shapes = []string{
@@ -302,6 +303,7 @@ var Shapes = []string{
 	ShapeClass,
 	ShapeSQLTable,
 	ShapeImage,
+	ShapeSequence,
 }
 
 func IsShape(s string) bool {
@@ -368,6 +370,7 @@ var DSL_SHAPE_TO_SHAPE_TYPE = map[string]string{
 	ShapeClass:         shape.CLASS_TYPE,
 	ShapeSQLTable:      shape.TABLE_TYPE,
 	ShapeImage:         shape.IMAGE_TYPE,
+	ShapeSequence:      shape.SQUARE_TYPE,
 }
 
 var SHAPE_TYPE_TO_DSL_SHAPE map[string]string

--- a/testdata/d2compiler/TestCompile/basic_sequence.exp.json
+++ b/testdata/d2compiler/TestCompile/basic_sequence.exp.json
@@ -1,11 +1,11 @@
 {
   "graph": {
     "ast": {
-      "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-3:0:25",
+      "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-3:0:33",
       "nodes": [
         {
           "map_key": {
-            "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-2:1:24",
+            "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-2:1:32",
             "key": {
               "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-0:1:1",
               "path": [
@@ -25,11 +25,11 @@
             "primary": {},
             "value": {
               "map": {
-                "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:3:3-2:0:23",
+                "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:3:3-2:0:31",
                 "nodes": [
                   {
                     "map_key": {
-                      "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:2:7-1:17:22",
+                      "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:2:7-1:25:30",
                       "key": {
                         "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:2:7-1:7:12",
                         "path": [
@@ -49,11 +49,11 @@
                       "primary": {},
                       "value": {
                         "unquoted_string": {
-                          "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:9:14-1:17:22",
+                          "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:9:14-1:25:30",
                           "value": [
                             {
-                              "string": "sequence",
-                              "raw_string": "sequence"
+                              "string": "sequence_diagram",
+                              "raw_string": "sequence_diagram"
                             }
                           ]
                         }
@@ -123,7 +123,7 @@
           "style": {},
           "near_key": null,
           "shape": {
-            "value": "sequence"
+            "value": "sequence_diagram"
           }
         }
       }

--- a/testdata/d2compiler/TestCompile/basic_sequence.exp.json
+++ b/testdata/d2compiler/TestCompile/basic_sequence.exp.json
@@ -1,0 +1,133 @@
+{
+  "graph": {
+    "ast": {
+      "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-3:0:25",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-2:1:24",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:3:3-2:0:23",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:2:7-1:17:22",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:2:7-1:7:12",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:2:7-1:7:12",
+                              "value": [
+                                {
+                                  "string": "shape",
+                                  "raw_string": "shape"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,1:9:14-1:17:22",
+                          "value": [
+                            {
+                              "string": "sequence",
+                              "raw_string": "sequence"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "label_dimensions": {
+        "width": 0,
+        "height": 0
+      },
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        }
+      }
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "x",
+        "id_val": "x",
+        "label_dimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/basic_sequence.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "x"
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "sequence"
+          }
+        }
+      }
+    ]
+  },
+  "err": null
+}

--- a/testdata/d2compiler/TestCompile/root_sequence.exp.json
+++ b/testdata/d2compiler/TestCompile/root_sequence.exp.json
@@ -1,0 +1,63 @@
+{
+  "graph": {
+    "ast": {
+      "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-1:0:16",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-0:15:15",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-0:5:5",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-0:5:5",
+                    "value": [
+                      {
+                        "string": "shape",
+                        "raw_string": "shape"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "unquoted_string": {
+                "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:7:7-0:15:15",
+                "value": [
+                  {
+                    "string": "sequence",
+                    "raw_string": "sequence"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "label_dimensions": {
+        "width": 0,
+        "height": 0
+      },
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": "sequence"
+        }
+      }
+    },
+    "edges": null,
+    "objects": null
+  },
+  "err": null
+}

--- a/testdata/d2compiler/TestCompile/root_sequence.exp.json
+++ b/testdata/d2compiler/TestCompile/root_sequence.exp.json
@@ -1,11 +1,11 @@
 {
   "graph": {
     "ast": {
-      "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-1:0:16",
+      "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-1:0:24",
       "nodes": [
         {
           "map_key": {
-            "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-0:15:15",
+            "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-0:23:23",
             "key": {
               "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:0:0-0:5:5",
               "path": [
@@ -25,11 +25,11 @@
             "primary": {},
             "value": {
               "unquoted_string": {
-                "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:7:7-0:15:15",
+                "range": "d2/testdata/d2compiler/TestCompile/root_sequence.d2,0:7:7-0:23:23",
                 "value": [
                   {
-                    "string": "sequence",
-                    "raw_string": "sequence"
+                    "string": "sequence_diagram",
+                    "raw_string": "sequence_diagram"
                   }
                 ]
               }
@@ -52,7 +52,7 @@
         "style": {},
         "near_key": null,
         "shape": {
-          "value": "sequence"
+          "value": "sequence_diagram"
         }
       }
     },


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

This enables running sequence layout engine only on sequence shapes.

Supports #99 