### PR TITLE
Fix span render

### DIFF
--- a/d2layouts/d2sequence/layout.go
+++ b/d2layouts/d2sequence/layout.go
@@ -218,6 +218,7 @@ func (sd *sequenceDiagram) placeSpans() {
 		width := SPAN_WIDTH + (float64(span.Level()-2) * SPAN_DEPTH_GROW_FACTOR)
 		x := rankToX[sd.objectRank[span]] - (width / 2.)
 		span.Box = geo.NewBox(geo.NewPoint(x, minY), width, height)
+		span.ZIndex = 1
 	}
 }
 

--- a/d2layouts/d2sequence/layout_test.go
+++ b/d2layouts/d2sequence/layout_test.go
@@ -208,6 +208,12 @@ func TestSpansSequenceDiagram(t *testing.T) {
 		t.Fatalf("expected a.t1 and b.t1 to have the same height, got %.5f and %.5f", a_t1.Height, b_t1.Height)
 	}
 
+	for _, span := range []*d2graph.Object{a_t1, a_t2, b_t1} {
+		if span.ZIndex != 1 {
+			t.Fatalf("expected span ZIndex=1, got %d", span.ZIndex)
+		}
+	}
+
 	// Y diff of the 2 first edges
 	expectedHeight := g.Edges[1].Route[0].Y - g.Edges[0].Route[0].Y + (2 * SPAN_EDGE_PAD)
 	if a_t1.Height != expectedHeight {


### PR DESCRIPTION
Supports #99 

Set index for spans to 1 so that they are rendered after everything else
![_Users_juliobatista_Projects_terrastruct_d2_sequence svg (2)](https://user-images.githubusercontent.com/102628724/204914316-ecd2e3b8-8900-4b6f-95bb-29a170e043ec.png)
