### PR TITLE
lib/version: Set to HEAD when building from source instead of ????

### DIFF
--- a/lib/version/version.go
+++ b/lib/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-// Pre-built binaries will have version set during build time.
-var Version = "HEAD"
+// Pre-built binaries will have version set correctly during build time.
+var Version = "v0.0.13-HEAD"

--- a/lib/version/version.go
+++ b/lib/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Pre-built binaries will have version set during build time.
-var Version = "????"
+var Version = "HEAD"


### PR DESCRIPTION
More clear. See https://github.com/terrastruct/d2/issues/202
