### PR TITLE
watch.go: Ignore first error in ensureAddWatch

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -36,5 +36,7 @@
   [#159](https://github.com/terrastruct/d2/issues/159)
 - Fixes markdown newlines created with a trailing double space or backslash.
   [#214](https://github.com/terrastruct/d2/pull/214)
-- Fixes images not loading in PNG exports
+- Fixes images not loading in PNG exports.
   [#224](https://github.com/terrastruct/d2/pull/224)
+- Avoid logging benign file watching errors.
+  [#293](https://github.com/terrastruct/d2/pull/293)


### PR DESCRIPTION
Will prevent the benign watching errors we've been seeing.
I feel like there was an open issue for this but I cannot find it.
