### PR TITLE
Add markdown TOC generation using pandoc and shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: fmt gen lint build test
 
 .PHONY: fmt
 fmt:
-	prefix "$@" ./ci/sub/fmt/make.sh
+	prefix "$@" ./ci/fmt.sh
 .PHONY: gen
 gen:
 	prefix "$@" ./ci/gen.sh

--- a/README.md
+++ b/README.md
@@ -19,27 +19,24 @@
 # Table of Contents
 
 <!-- toc -->
-
-- [What does D2 look like?](#what-does-d2-look-like)
-- [Quickstart](#quickstart)
-- [Install](#install)
-- [D2 as a library](#d2-as-a-library)
-- [Themes](#themes)
-- [Fonts](#fonts)
-- [Export file types](#export-file-types)
-- [Language tooling](#language-tooling)
-- [Plugins](#plugins)
-- [Comparison](#comparison)
-- [Contributing](#contributing)
-- [License](#license)
-- [Related](#related)
-  * [VSCode extension](#vscode-extension)
-  * [Vim extension](#vim-extension)
-  * [Language docs](#language-docs)
-  * [Misc](#misc)
-- [FAQ](#faq)
-
-<!-- tocstop -->
+- <a href="#what-does-d2-look-like" id="toc-what-does-d2-look-like">What does D2 look like?</a>
+- <a href="#quickstart" id="toc-quickstart">Quickstart</a>
+- <a href="#install" id="toc-install">Install</a>
+- <a href="#d2-as-a-library" id="toc-d2-as-a-library">D2 as a library</a>
+- <a href="#themes" id="toc-themes">Themes</a>
+- <a href="#fonts" id="toc-fonts">Fonts</a>
+- <a href="#export-file-types" id="toc-export-file-types">Export file types</a>
+- <a href="#language-tooling" id="toc-language-tooling">Language tooling</a>
+- <a href="#plugins" id="toc-plugins">Plugins</a>
+- <a href="#comparison" id="toc-comparison">Comparison</a>
+- <a href="#contributing" id="toc-contributing">Contributing</a>
+- <a href="#license" id="toc-license">License</a>
+- <a href="#related" id="toc-related">Related</a>
+  - <a href="#vscode-extension" id="toc-vscode-extension">VSCode extension</a>
+  - <a href="#vim-extension" id="toc-vim-extension">Vim extension</a>
+  - <a href="#language-docs" id="toc-language-docs">Language docs</a>
+  - <a href="#misc" id="toc-misc">Misc</a>
+- <a href="#faq" id="toc-faq">FAQ</a>
 
 ## What does D2 look like?
 

--- a/ci/fmt.sh
+++ b/ci/fmt.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+. "$(dirname "$0")/sub/lib.sh"
+cd -- "$(dirname "$0")/.."
+
+sh_c tocsubst --skip 1 README.md
+./ci/sub/fmt/make.sh

--- a/ci/fmt.sh
+++ b/ci/fmt.sh
@@ -3,5 +3,7 @@ set -eu
 . "$(dirname "$0")/sub/lib.sh"
 cd -- "$(dirname "$0")/.."
 
-sh_c tocsubst --skip 1 README.md
+if is_changed README.md; then
+  sh_c tocsubst --skip 1 README.md
+fi
 ./ci/sub/fmt/make.sh


### PR DESCRIPTION
See https://github.com/terrastruct/ci/blob/a875763eccbb51298807901be68c31e5b150dceb/lib/misc.sh#L28

The TOC is generated via pandoc and inserted via shell. `<!-- toc -->`
marks the insertion point, the TOC is inserted right below.

I'm using this in utils-go too. We should use it anywhere else we need
TOCs. I'm sure pandoc can handle the frontmatter in d2-docs too.
