### PR TITLE
release: Build with -trimpath

### DIFF
--- a/ci/release/_build.sh
+++ b/ci/release/_build.sh
@@ -13,7 +13,7 @@ sh_c find "$HW_BUILD_DIR" -exec touch {} \\\;
 ensure_goos
 ensure_goarch
 sh_c mkdir -p "$HW_BUILD_DIR/bin"
-sh_c CGO_ENABLED=0 go build \
+sh_c CGO_ENABLED=0 go build -trimpath \
   -ldflags "'-X oss.terrastruct.com/d2/lib/version.Version=$VERSION'" \
   -o "$HW_BUILD_DIR/bin/d2" .
 


### PR DESCRIPTION
-trimpath prevents paths from the builder showing up in the
binary on panics and whatnot.
