### PR TITLE
fix builds on 32bit systems

### DIFF
--- a/d2layouts/d2sequence/sequence_diagram.go
+++ b/d2layouts/d2sequence/sequence_diagram.go
@@ -43,7 +43,7 @@ type sequenceDiagram struct {
 }
 
 func getObjEarliestLineNum(o *d2graph.Object) int {
-	min := int(math.MaxInt64)
+	min := int(math.MaxInt32)
 	for _, ref := range o.References {
 		if ref.MapKey == nil {
 			continue
@@ -54,7 +54,7 @@ func getObjEarliestLineNum(o *d2graph.Object) int {
 }
 
 func getEdgeEarliestLineNum(e *d2graph.Edge) int {
-	min := int(math.MaxInt64)
+	min := int(math.MaxInt32)
 	for _, ref := range e.References {
 		if ref.MapKey == nil {
 			continue

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -47,10 +47,10 @@ func (diagram Diagram) BoundingBox() (topLeft, bottomRight Point) {
 	if len(diagram.Shapes) == 0 {
 		return Point{0, 0}, Point{0, 0}
 	}
-	x1 := int(math.MaxInt64)
-	y1 := int(math.MaxInt64)
-	x2 := int(-math.MaxInt64)
-	y2 := int(-math.MaxInt64)
+	x1 := int(math.MaxInt32)
+	y1 := int(math.MaxInt32)
+	x2 := int(math.MinInt32)
+	y2 := int(math.MinInt32)
 
 	for _, targetShape := range diagram.Shapes {
 		x1 = go2.Min(x1, targetShape.Pos.X)


### PR DESCRIPTION
This is to supersede #395 with an alternative that fixes the initial problem by ignoring it -- let's NOT do 64 bit integers!

That should be fine, right?

I also didn't include the go fmt changes for ascii art.