### PR TITLE
fix empty diagram

### DIFF
--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -44,6 +44,9 @@ func (diagram Diagram) HashID() (string, error) {
 }
 
 func (diagram Diagram) BoundingBox() (topLeft, bottomRight Point) {
+	if len(diagram.Shapes) == 0 {
+		return Point{0, 0}, Point{0, 0}
+	}
 	x1 := int(math.MaxInt64)
 	y1 := int(math.MaxInt64)
 	x2 := int(-math.MaxInt64)

--- a/e2etests/testdata/sanity/empty/dagre/sketch.exp.svg
+++ b/e2etests/testdata/sanity/empty/dagre/sketch.exp.svg
@@ -2,7 +2,7 @@
 <svg
 style="background: white;"
 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-width="202" height="202" viewBox="9223372036854775707 9223372036854775707 202 202"><style type="text/css">
+width="200" height="200" viewBox="-100 -100 200 200"><style type="text/css">
 <![CDATA[
 .shape {
   shape-rendering: geometricPrecision;

--- a/e2etests/testdata/sanity/empty/elk/sketch.exp.svg
+++ b/e2etests/testdata/sanity/empty/elk/sketch.exp.svg
@@ -2,7 +2,7 @@
 <svg
 style="background: white;"
 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-width="202" height="202" viewBox="9223372036854775707 9223372036854775707 202 202"><style type="text/css">
+width="200" height="200" viewBox="-100 -100 200 200"><style type="text/css">
 <![CDATA[
 .shape {
   shape-rendering: geometricPrecision;


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

found through https://github.com/terrastruct/d2/actions/runs/3635230859/jobs/6134140375 

shouldn't be setting empty diagram viewbox to ridiculous number