### PR TITLE
fmt: Preserve leading comment spacing

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -5,6 +5,9 @@
 
 #### Improvements 🧹
 
+- Fmt now preserves leading comment spacing.
+  [#400](https://github.com/terrastruct/d2/issues/400)
+
 #### Bugfixes ⛑️
 
 - Fixed crash when sequence diagrams had no messages.

--- a/d2format/format.go
+++ b/d2format/format.go
@@ -81,7 +81,7 @@ func (p *printer) comment(c *d2ast.Comment) {
 	lines := strings.Split(c.Value, "\n")
 	for i, line := range lines {
 		p.sb.WriteString("#")
-		if line != "" && !strings.HasPrefix(line, " ") {
+		if line != "" {
 			p.sb.WriteByte(' ')
 		}
 		p.sb.WriteString(line)

--- a/d2format/format_test.go
+++ b/d2format/format_test.go
@@ -594,6 +594,23 @@ hi # Fraud is the homage that force pays to reason.
 			exp: `x
 `,
 		},
+		{
+			name: "leading_space_comments",
+			in: `# foo
+#   foobar
+#     baz
+x  ->  y
+#foo
+y
+`,
+			exp: `# foo
+#   foobar
+#     baz
+x -> y
+# foo
+y
+`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

fixes #400 