### PR TITLE
fix urlencode compression determinism

### DIFF
--- a/lib/urlenc/urlenc.go
+++ b/lib/urlenc/urlenc.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"encoding/base64"
 	"io"
+	"sort"
 	"strings"
 
 	"oss.terrastruct.com/util-go/xdefer"
@@ -18,13 +19,18 @@ var compressionDict = "->" +
 	"<->"
 
 func init() {
+	var common []string
 	for k := range d2graph.StyleKeywords {
-		compressionDict += k
+		common = append(common, k)
 	}
 	for k := range d2graph.ReservedKeywords {
-		compressionDict += k
+		common = append(common, k)
 	}
 	for k := range d2graph.ReservedKeywordHolders {
+		common = append(common, k)
+	}
+	sort.Strings(common)
+	for _, k := range common {
 		compressionDict += k
 	}
 }


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

adding keys from maps results in non-deterministic compression dict