### PR TITLE
fix serialization casing

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -3,3 +3,6 @@
 #### Improvements 🧹
 
 #### Bugfixes ⛑️
+
+- Fixed serialization affecting binary plugins (TALA).
+  [https://github.com/terrastruct/d2/pull/426](https://github.com/terrastruct/d2/pull/426)

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -2,6 +2,7 @@ package d2graph
 
 import (
 	"encoding/json"
+	"strings"
 
 	"oss.terrastruct.com/util-go/go2"
 )
@@ -48,7 +49,7 @@ func DeserializeGraph(bytes []byte, g *Graph) error {
 			for _, id := range so["ChildrenArray"].([]interface{}) {
 				o := idToObj[id.(string)]
 				childrenArray = append(childrenArray, o)
-				children[id.(string)] = o
+				children[strings.ToLower(id.(string))] = o
 
 				o.Parent = idToObj[so["AbsID"].(string)]
 			}

--- a/d2graph/serde_test.go
+++ b/d2graph/serde_test.go
@@ -14,9 +14,7 @@ func TestSerialization(t *testing.T) {
 	t.Parallel()
 
 	g, err := d2compiler.Compile("", strings.NewReader("a.a.b -> a.a.c"), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 
 	asserts := func(g *d2graph.Graph) {
 		assert.Equal(t, 4, len(g.Objects))
@@ -41,15 +39,33 @@ func TestSerialization(t *testing.T) {
 	asserts(g)
 
 	b, err := d2graph.SerializeGraph(g)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 
 	var newG d2graph.Graph
 	err = d2graph.DeserializeGraph(b, &newG)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 
 	asserts(&newG)
+}
+
+func TestCasingRegression(t *testing.T) {
+	t.Parallel()
+
+	script := `UserCreatedTypeField`
+
+	g, err := d2compiler.Compile("", strings.NewReader(script), nil)
+	assert.Nil(t, err)
+
+	_, ok := g.Root.HasChild([]string{"UserCreatedTypeField"})
+	assert.True(t, ok)
+
+	b, err := d2graph.SerializeGraph(g)
+	assert.Nil(t, err)
+
+	var newG d2graph.Graph
+	err = d2graph.DeserializeGraph(b, &newG)
+	assert.Nil(t, err)
+
+	_, ok = newG.Root.HasChild([]string{"UserCreatedTypeField"})
+	assert.True(t, ok)
 }


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

binary plugins were getting a corrupted graph due to serde bug where object children were being set case sensitive