### PR TITLE
cli: add pad option

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -1,5 +1,8 @@
 #### Features 🚀
 
+- Diagram padding can now can be configured in the CLI (default 100px).
+  [https://github.com/terrastruct/d2/pull/431](https://github.com/terrastruct/d2/pull/431)
+
 #### Improvements 🧹
 
 #### Bugfixes ⛑️

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -58,6 +58,9 @@ Port listening address when used with
 Set the diagram theme to the passed integer. For a list of available options, see
 .Lk https://oss.terrastruct.com/d2
 .Ns .
+.It Fl -pad Ar 100
+Pixels padded around the rendered diagram
+.Ns .
 .It Fl l , -layout Ar dagre
 Set the diagram layout engine to the passed string. For a list of available options, run
 .Ar layout

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	padding                    = 100
+	DEFAULT_PADDING            = 100
 	MIN_ARROWHEAD_STROKE_WIDTH = 2
 	threeDeeOffset             = 15
 )
@@ -47,10 +47,10 @@ var styleCSS string
 //go:embed github-markdown.css
 var mdCSS string
 
-func setViewbox(writer io.Writer, diagram *d2target.Diagram) (width int, height int) {
+func setViewbox(writer io.Writer, diagram *d2target.Diagram, pad int) (width int, height int) {
 	tl, br := diagram.BoundingBox()
-	w := br.X - tl.X + padding*2
-	h := br.Y - tl.Y + padding*2
+	w := br.X - tl.X + pad*2
+	h := br.Y - tl.Y + pad*2
 	// TODO minify
 
 	// TODO background stuff. e.g. dotted, grid, colors
@@ -58,7 +58,7 @@ func setViewbox(writer io.Writer, diagram *d2target.Diagram) (width int, height 
 <svg
 style="background: white;"
 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-width="%d" height="%d" viewBox="%d %d %d %d">`, w, h, tl.X-padding, tl.Y-padding, w, h)
+width="%d" height="%d" viewBox="%d %d %d %d">`, w, h, tl.X-pad, tl.Y-pad, w, h)
 
 	return w, h
 }
@@ -949,9 +949,9 @@ func embedFonts(buf *bytes.Buffer) {
 }
 
 // TODO minify output at end
-func Render(diagram *d2target.Diagram) ([]byte, error) {
+func Render(diagram *d2target.Diagram, pad int) ([]byte, error) {
 	buf := &bytes.Buffer{}
-	w, h := setViewbox(buf, diagram)
+	w, h := setViewbox(buf, diagram, pad)
 
 	buf.WriteString(fmt.Sprintf(`<style type="text/css">
 <![CDATA[

--- a/docs/examples/lib/1-d2lib/d2lib.go
+++ b/docs/examples/lib/1-d2lib/d2lib.go
@@ -20,6 +20,6 @@ func main() {
 		Ruler:   ruler,
 		ThemeID: d2themescatalog.GrapeSoda.ID,
 	})
-	out, _ := d2svg.Render(diagram)
+	out, _ := d2svg.Render(diagram, d2svg.DEFAULT_PADDING)
 	_ = ioutil.WriteFile(filepath.Join("out.svg"), out, 0600)
 }

--- a/docs/examples/lib/3-lowlevel/lowlevel.go
+++ b/docs/examples/lib/3-lowlevel/lowlevel.go
@@ -21,6 +21,6 @@ func main() {
 	_ = graph.SetDimensions(nil, ruler)
 	_ = d2dagrelayout.Layout(context.Background(), graph)
 	diagram, _ := d2exporter.Export(context.Background(), graph, d2themescatalog.NeutralDefault.ID)
-	out, _ := d2svg.Render(diagram)
+	out, _ := d2svg.Render(diagram, d2svg.DEFAULT_PADDING)
 	_ = ioutil.WriteFile(filepath.Join("out.svg"), out, 0600)
 }

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -125,7 +125,7 @@ func run(t *testing.T, tc testCase) {
 		dataPath := filepath.Join("testdata", strings.TrimPrefix(t.Name(), "TestE2E/"), layoutName)
 		pathGotSVG := filepath.Join(dataPath, "sketch.got.svg")
 
-		svgBytes, err := d2svg.Render(diagram)
+		svgBytes, err := d2svg.Render(diagram, d2svg.DEFAULT_PADDING)
 		assert.Success(t, err)
 		err = os.MkdirAll(dataPath, 0755)
 		assert.Success(t, err)

--- a/watch.go
+++ b/watch.go
@@ -41,6 +41,7 @@ var staticFS embed.FS
 type watcherOpts struct {
 	layoutPlugin d2plugin.Plugin
 	themeID      int64
+	pad          int64
 	host         string
 	port         string
 	inputPath    string
@@ -354,7 +355,7 @@ func (w *watcher) compileLoop(ctx context.Context) error {
 			w.pw = newPW
 		}
 
-		svg, _, err := compile(ctx, w.ms, w.layoutPlugin, w.themeID, w.inputPath, w.outputPath, w.bundle, w.pw.Page)
+		svg, _, err := compile(ctx, w.ms, w.layoutPlugin, w.pad, w.themeID, w.inputPath, w.outputPath, w.bundle, w.pw.Page)
 		errs := ""
 		if err != nil {
 			if len(svg) > 0 {


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

i've been sneakily adjusting padding for myself to generate d2lang.com images. time to make this generally available.

Default padding vs `--pad=0`:

<img width="930" alt="Screen Shot 2022-12-11 at 11 30 49 PM" src="https://user-images.githubusercontent.com/3120367/206986472-bf7121d1-60a8-4c62-8163-1f6990c4698e.png">

<img width="406" alt="Screen Shot 2022-12-11 at 11 26 47 PM" src="https://user-images.githubusercontent.com/3120367/206986516-fb83422c-9287-48d4-aa9a-27b748d7a3e4.png">

<img width="654" alt="Screen Shot 2022-12-11 at 11 26 39 PM" src="https://user-images.githubusercontent.com/3120367/206986546-bfbb4879-6019-4627-a7f1-d715b74ededf.png">

closes #14 