### PR TITLE
changed README to say that d2 supports png now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ one, please see [./d2renderers/d2fonts](./d2renderers/d2fonts).
 
 ## Export file types
 
-D2 currently supports SVG exports. More coming soon.
+D2 currently supports SVG and PNG file exports. More coming soon. 
 
 ## Language tooling
 


### PR DESCRIPTION
d2 README showed only SVG exports accepted. Changed to add png as suggested by @alixander that this is currently supported now.
