### PR TITLE
render: outside connection label masking

### DIFF
--- a/ci/e2ereport.sh
+++ b/ci/e2ereport.sh
@@ -3,6 +3,7 @@ set -eu
 
 export REPORT_OUTPUT="out/e2e_report.html"
 rm -f $REPORT_OUTPUT
+export E2E_REPORT=1
 
 FORCE_COLOR=1 DEBUG=1 go run ./e2etests/report/main.go "$@";
 

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -7,6 +7,8 @@
 
 - Fmt now preserves leading comment spacing.
   [#400](https://github.com/terrastruct/d2/issues/400)
+- Improved readability of connection labels when they are placed above or below a connection.
+  [#414](https://github.com/terrastruct/d2/issues/414)
 
 #### Bugfixes ⛑️
 

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -383,32 +383,6 @@ func drawConnection(writer io.Writer, labelMaskID string, connection d2target.Co
 		labelTL.Y = math.Round(labelTL.Y)
 
 		if label.Position(connection.LabelPosition).IsOnEdge() {
-			strokeWidth := float64(connection.StrokeWidth)
-			tl, br := geo.Route(connection.Route).GetBoundingBox()
-			tl.X -= strokeWidth
-			tl.Y -= strokeWidth
-			br.X += strokeWidth
-			br.Y += strokeWidth
-			if connection.SrcArrow != d2target.NoArrowhead {
-				width, height := arrowheadDimensions(connection.SrcArrow, strokeWidth)
-				tl.X -= width
-				tl.Y -= height
-				br.X += width
-				br.Y += height
-			}
-			if connection.DstArrow != d2target.NoArrowhead {
-				width, height := arrowheadDimensions(connection.DstArrow, strokeWidth)
-				tl.X -= width
-				tl.Y -= height
-				br.X += width
-				br.Y += height
-			}
-
-			tl.X = math.Min(tl.X, labelTL.X)
-			tl.Y = math.Min(tl.Y, labelTL.Y)
-			br.X = math.Max(br.X, labelTL.X+float64(connection.LabelWidth))
-			br.Y = math.Max(br.Y, labelTL.Y+float64(connection.LabelHeight))
-
 			labelMask = makeLabelMask(labelTL, connection.LabelWidth, connection.LabelHeight)
 		}
 	}

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -382,9 +382,7 @@ func drawConnection(writer io.Writer, labelMaskID string, connection d2target.Co
 		labelTL.X = math.Round(labelTL.X)
 		labelTL.Y = math.Round(labelTL.Y)
 
-		if label.Position(connection.LabelPosition).IsOnEdge() {
-			labelMask = makeLabelMask(labelTL, connection.LabelWidth, connection.LabelHeight)
-		}
+		labelMask = makeLabelMask(labelTL, connection.LabelWidth, connection.LabelHeight)
 	}
 
 	fmt.Fprintf(writer, `<path d="%s" class="connection" style="fill:none;%s" %s%smask="url(#%s)"/>`,

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -131,7 +131,11 @@ func run(t *testing.T, tc testCase) {
 		assert.Success(t, err)
 		err = ioutil.WriteFile(pathGotSVG, svgBytes, 0600)
 		assert.Success(t, err)
-		defer os.Remove(pathGotSVG)
+		// if running from e2ereport.sh, we want to keep .got.svg on a failure
+		forReport := os.Getenv("E2E_REPORT") != ""
+		if !forReport {
+			defer os.Remove(pathGotSVG)
+		}
 
 		var xmlParsed interface{}
 		err = xml.Unmarshal(svgBytes, &xmlParsed)
@@ -142,6 +146,9 @@ func run(t *testing.T, tc testCase) {
 		if os.Getenv("SKIP_SVG_CHECK") == "" {
 			err = diff.Testdata(filepath.Join(dataPath, "sketch"), ".svg", svgBytes)
 			assert.Success(t, err)
+		}
+		if forReport {
+			os.Remove(pathGotSVG)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

We only added label masks when the label is placed over the connection, but when TALA places labels above or below connections the labels could still overlap other connections at times.
This fixes the issue by always adding label masks so that even if the label is over part of another connection the mask will still be applied for improved legibility.

## Details
- fixes #414 
- fixes `.got.svg` files being deleted when running `./ci/e2ereport.sh`
- currently only TALA places labels in outside positions so we don't have any e2e tests that would reproduce this


