### PR TITLE
only write fmt if changed

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -3,3 +3,5 @@
 #### Improvements 🧹
 
 #### Bugfixes ⛑️
+
+- `d2 fmt` only rewrites if it has changes, instead of always rewriting. [#470](https://github.com/terrastruct/d2/pull/470)

--- a/fmt.go
+++ b/fmt.go
@@ -33,5 +33,10 @@ func fmtCmd(ctx context.Context, ms *xmain.State) (err error) {
 		return err
 	}
 
-	return ms.WritePath(inputPath, []byte(d2format.Format(m)))
+	output := []byte(d2format.Format(m))
+	if !bytes.Equal(output, input) {
+		return ms.WritePath(inputPath, output)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

fixes #469 

match behavior of gofmt: https://github.com/golang/go/blob/master/src/cmd/gofmt/gofmt.go#L266

tested the original issue's command and confirmed it only writes once as expected

<img width="382" alt="Screen Shot 2022-12-19 at 1 18 17 PM" src="https://user-images.githubusercontent.com/3120367/208526773-fb94e7ec-5a85-4ade-8a05-73719269a477.png">
