### PR TITLE
fix e2ereport script with delta flag

### DIFF
--- a/ci/e2ereport.sh
+++ b/ci/e2ereport.sh
@@ -3,6 +3,7 @@ set -eu
 
 export REPORT_OUTPUT="out/e2e_report.html"
 rm -f $REPORT_OUTPUT
+export E2E_REPORT=1
 
 FORCE_COLOR=1 DEBUG=1 go run ./e2etests/report/main.go "$@";
 

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -131,7 +131,11 @@ func run(t *testing.T, tc testCase) {
 		assert.Success(t, err)
 		err = ioutil.WriteFile(pathGotSVG, svgBytes, 0600)
 		assert.Success(t, err)
-		defer os.Remove(pathGotSVG)
+		// if running from e2ereport.sh, we want to keep .got.svg on a failure
+		forReport := os.Getenv("E2E_REPORT") != ""
+		if !forReport {
+			defer os.Remove(pathGotSVG)
+		}
 
 		var xmlParsed interface{}
 		err = xml.Unmarshal(svgBytes, &xmlParsed)
@@ -142,6 +146,9 @@ func run(t *testing.T, tc testCase) {
 		if os.Getenv("SKIP_SVG_CHECK") == "" {
 			err = diff.Testdata(filepath.Join(dataPath, "sketch"), ".svg", svgBytes)
 			assert.Success(t, err)
+		}
+		if forReport {
+			os.Remove(pathGotSVG)
 		}
 	}
 }


### PR DESCRIPTION

## Summary

Fixes .got.svg files being deleted for changed tests when running ./ci/e2ereport.sh with -delta flag. These are needed to produce the report.

## Details
- when running the report, only delete the `.got.svg` files if there were no changes
- separated change out from #447
