### PR TITLE
Pass layout configs

### DIFF
--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -82,7 +82,7 @@ Print version information and exit.
 .It Ar layout
 Lists available layout engine options with short help.
 .It Ar layout Op Ar name
-Display long help for a particular layout engine.
+Display long help for a particular layout engine, including its configuration options.
 .It Ar fmt Ar file.d2
 Format
 .Ar file.d2

--- a/cmd/d2plugin-dagre/main.go
+++ b/cmd/d2plugin-dagre/main.go
@@ -9,5 +9,5 @@ import (
 )
 
 func main() {
-	xmain.Main(d2plugin.Serve(d2plugin.DagrePlugin))
+	xmain.Main(d2plugin.Serve(&d2plugin.DagrePlugin))
 }

--- a/d2chaos/d2chaos_test.go
+++ b/d2chaos/d2chaos_test.go
@@ -123,7 +123,7 @@ func test(t *testing.T, textPath, text string) {
 		err = g.SetDimensions(nil, ruler, nil)
 		assert.Nil(t, err)
 
-		err = d2dagrelayout.Layout(ctx, g)
+		err = d2dagrelayout.DefaultLayout(ctx, g)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/d2exporter/export_test.go
+++ b/d2exporter/export_test.go
@@ -239,7 +239,7 @@ func run(t *testing.T, tc testCase) {
 	err = g.SetDimensions(nil, ruler, nil)
 	assert.JSON(t, nil, err)
 
-	err = d2sequence.Layout(ctx, g, d2dagrelayout.Layout)
+	err = d2sequence.Layout(ctx, g, d2dagrelayout.DefaultLayout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -30,12 +30,12 @@ var setupJS string
 //go:embed dagre.js
 var dagreJS string
 
-type Opts struct {
+type ConfigurableOpts struct {
 	NodeSep int
 	EdgeSep int
 }
 
-var DefaultOpts = Opts{
+var DefaultOpts = ConfigurableOpts{
 	NodeSep: 60,
 	EdgeSep: 40,
 }
@@ -52,16 +52,16 @@ type DagreEdge struct {
 	Points []*geo.Point `json:"points"`
 }
 
-type dagreGraphAttrs struct {
+type dagreOpts struct {
 	// for a top to bottom graph: ranksep is y spacing, nodesep is x spacing, edgesep is x spacing
 	ranksep int
-	edgesep int
-	nodesep int
 	// graph direction: tb (top to bottom)| bt | lr | rl
 	rankdir string
+
+	ConfigurableOpts
 }
 
-func Layout(ctx context.Context, g *d2graph.Graph, opts *Opts) (err error) {
+func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err error) {
 	if opts == nil {
 		opts = &DefaultOpts
 	}
@@ -76,9 +76,11 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *Opts) (err error) {
 		return err
 	}
 
-	rootAttrs := dagreGraphAttrs{
-		edgesep: opts.EdgeSep,
-		nodesep: opts.NodeSep,
+	rootAttrs := dagreOpts{
+		ConfigurableOpts: ConfigurableOpts{
+			EdgeSep: opts.EdgeSep,
+			NodeSep: opts.NodeSep,
+		},
 	}
 	isHorizontal := false
 	switch g.Root.Attributes.Direction.Value {
@@ -279,7 +281,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *Opts) (err error) {
 	return nil
 }
 
-func setGraphAttrs(attrs dagreGraphAttrs) string {
+func setGraphAttrs(attrs dagreOpts) string {
 	return fmt.Sprintf(`g.setGraph({
   ranksep: %d,
   edgesep: %d,
@@ -288,8 +290,8 @@ func setGraphAttrs(attrs dagreGraphAttrs) string {
 });
 `,
 		attrs.ranksep,
-		attrs.edgesep,
-		attrs.nodesep,
+		attrs.ConfigurableOpts.EdgeSep,
+		attrs.ConfigurableOpts.NodeSep,
 		attrs.rankdir,
 	)
 }

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -61,6 +61,10 @@ type dagreOpts struct {
 	ConfigurableOpts
 }
 
+func DefaultLayout(ctx context.Context, g *d2graph.Graph) (err error) {
+	return Layout(ctx, g, nil)
+}
+
 func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err error) {
 	if opts == nil {
 		opts = &DefaultOpts

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -30,6 +30,14 @@ var setupJS string
 //go:embed dagre.js
 var dagreJS string
 
+type Opts struct {
+	NodeSep int
+}
+
+var DefaultOpts = Opts{
+	NodeSep: 60,
+}
+
 type DagreNode struct {
 	ID     string  `json:"id"`
 	X      float64 `json:"x"`
@@ -51,7 +59,10 @@ type dagreGraphAttrs struct {
 	rankdir string
 }
 
-func Layout(ctx context.Context, g *d2graph.Graph) (err error) {
+func Layout(ctx context.Context, g *d2graph.Graph, opts *Opts) (err error) {
+	if opts == nil {
+		opts = &DefaultOpts
+	}
 	defer xdefer.Errorf(&err, "failed to dagre layout")
 
 	debugJS := false
@@ -65,7 +76,7 @@ func Layout(ctx context.Context, g *d2graph.Graph) (err error) {
 
 	rootAttrs := dagreGraphAttrs{
 		edgesep: 40,
-		nodesep: 60,
+		nodesep: opts.NodeSep,
 	}
 	isHorizontal := false
 	switch g.Root.Attributes.Direction.Value {

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -32,10 +32,12 @@ var dagreJS string
 
 type Opts struct {
 	NodeSep int
+	EdgeSep int
 }
 
 var DefaultOpts = Opts{
 	NodeSep: 60,
+	EdgeSep: 40,
 }
 
 type DagreNode struct {
@@ -75,7 +77,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *Opts) (err error) {
 	}
 
 	rootAttrs := dagreGraphAttrs{
-		edgesep: 40,
+		edgesep: opts.EdgeSep,
 		nodesep: opts.NodeSep,
 	}
 	isHorizontal := false

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -31,8 +31,8 @@ var setupJS string
 var dagreJS string
 
 type ConfigurableOpts struct {
-	NodeSep int
-	EdgeSep int
+	NodeSep int `json:"nodesep"`
+	EdgeSep int `json:"edgesep"`
 }
 
 var DefaultOpts = ConfigurableOpts{

--- a/d2layouts/d2elklayout/layout.go
+++ b/d2layouts/d2elklayout/layout.go
@@ -103,6 +103,10 @@ type elkOpts struct {
 	ConfigurableOpts
 }
 
+func DefaultLayout(ctx context.Context, g *d2graph.Graph) (err error) {
+	return Layout(ctx, g, nil)
+}
+
 func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err error) {
 	if opts == nil {
 		opts = &DefaultOpts

--- a/d2layouts/d2elklayout/layout.go
+++ b/d2layouts/d2elklayout/layout.go
@@ -31,23 +31,23 @@ var elkJS string
 var setupJS string
 
 type ELKNode struct {
-	ID            string            `json:"id"`
-	X             float64           `json:"x"`
-	Y             float64           `json:"y"`
-	Width         float64           `json:"width"`
-	Height        float64           `json:"height"`
-	Children      []*ELKNode        `json:"children,omitempty"`
-	Labels        []*ELKLabel       `json:"labels,omitempty"`
-	LayoutOptions *ELKLayoutOptions `json:"layoutOptions,omitempty"`
+	ID            string      `json:"id"`
+	X             float64     `json:"x"`
+	Y             float64     `json:"y"`
+	Width         float64     `json:"width"`
+	Height        float64     `json:"height"`
+	Children      []*ELKNode  `json:"children,omitempty"`
+	Labels        []*ELKLabel `json:"labels,omitempty"`
+	LayoutOptions *elkOpts    `json:"layoutOptions,omitempty"`
 }
 
 type ELKLabel struct {
-	Text          string            `json:"text"`
-	X             float64           `json:"x"`
-	Y             float64           `json:"y"`
-	Width         float64           `json:"width"`
-	Height        float64           `json:"height"`
-	LayoutOptions *ELKLayoutOptions `json:"layoutOptions,omitempty"`
+	Text          string   `json:"text"`
+	X             float64  `json:"x"`
+	Y             float64  `json:"y"`
+	Width         float64  `json:"width"`
+	Height        float64  `json:"height"`
+	LayoutOptions *elkOpts `json:"layoutOptions,omitempty"`
 }
 
 type ELKPoint struct {
@@ -71,18 +71,10 @@ type ELKEdge struct {
 }
 
 type ELKGraph struct {
-	ID            string            `json:"id"`
-	LayoutOptions *ELKLayoutOptions `json:"layoutOptions"`
-	Children      []*ELKNode        `json:"children,omitempty"`
-	Edges         []*ELKEdge        `json:"edges,omitempty"`
-}
-
-var DefaultOpts = ConfigurableOpts{
-	Algorithm:       "layered",
-	NodeSpacing:     100.0,
-	Padding:         "[top=75,left=75,bottom=75,right=75]",
-	EdgeNodeSpacing: 50.0,
-	SelfLoopSpacing: 50.0,
+	ID            string     `json:"id"`
+	LayoutOptions *elkOpts   `json:"layoutOptions"`
+	Children      []*ELKNode `json:"children,omitempty"`
+	Edges         []*ELKEdge `json:"edges,omitempty"`
 }
 
 type ConfigurableOpts struct {
@@ -93,7 +85,15 @@ type ConfigurableOpts struct {
 	SelfLoopSpacing int    `json:"elk.spacing.nodeSelfLoop"`
 }
 
-type ELKLayoutOptions struct {
+var DefaultOpts = ConfigurableOpts{
+	Algorithm:       "layered",
+	NodeSpacing:     100.0,
+	Padding:         "[top=75,left=75,bottom=75,right=75]",
+	EdgeNodeSpacing: 50.0,
+	SelfLoopSpacing: 50.0,
+}
+
+type elkOpts struct {
 	Direction           string `json:"elk.direction"`
 	HierarchyHandling   string `json:"elk.hierarchyHandling,omitempty"`
 	InlineEdgeLabels    bool   `json:"elk.edgeLabels.inline,omitempty"`
@@ -125,7 +125,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 
 	elkGraph := &ELKGraph{
 		ID: "root",
-		LayoutOptions: &ELKLayoutOptions{
+		LayoutOptions: &elkOpts{
 			HierarchyHandling:  "INCLUDE_CHILDREN",
 			ConsiderModelOrder: "NODES_AND_EDGES",
 			ConfigurableOpts:   *opts,
@@ -171,7 +171,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 		}
 
 		if len(obj.ChildrenArray) > 0 {
-			n.LayoutOptions = &ELKLayoutOptions{
+			n.LayoutOptions = &elkOpts{
 				ForceNodeModelOrder: true,
 				ConfigurableOpts: ConfigurableOpts{
 					Padding: opts.Padding,
@@ -206,7 +206,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 				Text:   edge.Attributes.Label.Value,
 				Width:  float64(edge.LabelDimensions.Width),
 				Height: float64(edge.LabelDimensions.Height),
-				LayoutOptions: &ELKLayoutOptions{
+				LayoutOptions: &elkOpts{
 					InlineEdgeLabels: true,
 				},
 			})

--- a/d2layouts/d2elklayout/layout.go
+++ b/d2layouts/d2elklayout/layout.go
@@ -132,7 +132,12 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 		LayoutOptions: &elkOpts{
 			HierarchyHandling:  "INCLUDE_CHILDREN",
 			ConsiderModelOrder: "NODES_AND_EDGES",
-			ConfigurableOpts:   *opts,
+			ConfigurableOpts: ConfigurableOpts{
+				Algorithm:       opts.Algorithm,
+				NodeSpacing:     opts.NodeSpacing,
+				EdgeNodeSpacing: opts.EdgeNodeSpacing,
+				SelfLoopSpacing: opts.SelfLoopSpacing,
+			},
 		},
 	}
 	switch g.Root.Attributes.Direction.Value {

--- a/d2layouts/d2elklayout/layout.go
+++ b/d2layouts/d2elklayout/layout.go
@@ -77,6 +77,15 @@ type ELKGraph struct {
 	Edges         []*ELKEdge        `json:"edges,omitempty"`
 }
 
+var DefaultOpts = ELKLayoutOptions{
+	Algorithm:          "layered",
+	HierarchyHandling:  "INCLUDE_CHILDREN",
+	NodeSpacing:        100.0,
+	EdgeNodeSpacing:    50.0,
+	SelfLoopSpacing:    50.0,
+	ConsiderModelOrder: "NODES_AND_EDGES",
+}
+
 type ELKLayoutOptions struct {
 	Algorithm           string  `json:"elk.algorithm,omitempty"`
 	HierarchyHandling   string  `json:"elk.hierarchyHandling,omitempty"`
@@ -90,7 +99,10 @@ type ELKLayoutOptions struct {
 	ForceNodeModelOrder bool    `json:"elk.layered.crossingMinimization.forceNodeModelOrder,omitempty"`
 }
 
-func Layout(ctx context.Context, g *d2graph.Graph) (err error) {
+func Layout(ctx context.Context, g *d2graph.Graph, opts *ELKLayoutOptions) (err error) {
+	if opts == nil {
+		opts = &DefaultOpts
+	}
 	defer xdefer.Errorf(&err, "failed to ELK layout")
 
 	vm := goja.New()

--- a/d2lib/c.go
+++ b/d2lib/c.go
@@ -1,7 +1,0 @@
-package d2lib
-
-import "oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
-
-func init() {
-	dagreLayout = d2dagrelayout.Layout
-}

--- a/d2lib/d2.go
+++ b/d2lib/d2.go
@@ -9,6 +9,7 @@ import (
 	"oss.terrastruct.com/d2/d2compiler"
 	"oss.terrastruct.com/d2/d2exporter"
 	"oss.terrastruct.com/d2/d2graph"
+	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
 	"oss.terrastruct.com/d2/d2layouts/d2near"
 	"oss.terrastruct.com/d2/d2layouts/d2sequence"
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"
@@ -74,12 +75,12 @@ func Compile(ctx context.Context, input string, opts *CompileOptions) (*d2target
 func getLayout(opts *CompileOptions) (func(context.Context, *d2graph.Graph) error, error) {
 	if opts.Layout != nil {
 		return opts.Layout, nil
-	} else if os.Getenv("D2_LAYOUT") == "dagre" && dagreLayout != nil {
-		return dagreLayout, nil
+	} else if os.Getenv("D2_LAYOUT") == "dagre" {
+		defaultLayout := func(ctx context.Context, g *d2graph.Graph) error {
+			return d2dagrelayout.Layout(ctx, g, nil)
+		}
+		return defaultLayout, nil
 	} else {
 		return nil, errors.New("no available layout")
 	}
 }
-
-// See c.go
-var dagreLayout func(context.Context, *d2graph.Graph) error

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -41,10 +41,16 @@ type execPlugin struct {
 	opts map[string]string
 }
 
-func (p execPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
+func (p execPlugin) Flags() []PluginSpecificFlag {
+	// TODO
+	return nil
+}
+
+func (p *execPlugin) HydrateOpts(opts []byte) error {
 	if opts != nil {
-		execOpts, ok := opts.(map[string]string)
-		if !ok {
+		var execOpts map[string]string
+		err := json.Unmarshal(opts, &execOpts)
+		if err != nil {
 			return xmain.UsageErrorf("non-exec layout options given for exec")
 		}
 

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"oss.terrastruct.com/util-go/xdefer"
+	"oss.terrastruct.com/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2graph"
 )
@@ -37,6 +38,19 @@ import (
 // the error to stderr.
 type execPlugin struct {
 	path string
+	opts map[string]string
+}
+
+func (p execPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
+	if opts != nil {
+		execOpts, ok := opts.(map[string]string)
+		if !ok {
+			return xmain.UsageErrorf("non-exec layout options given for exec")
+		}
+
+		p.opts = execOpts
+	}
+	return nil
 }
 
 func (p execPlugin) Info(ctx context.Context) (_ *PluginInfo, err error) {

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -113,7 +113,11 @@ func (p execPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
 		return err
 	}
 
-	cmd := exec.CommandContext(ctx, p.path, "layout")
+	args := []string{"layout"}
+	for k, v := range p.opts {
+		args = append(args, k, v)
+	}
+	cmd := exec.CommandContext(ctx, p.path, args...)
 
 	buffer := bytes.Buffer{}
 	buffer.Write(graphBytes)

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -23,6 +23,8 @@ type Plugin interface {
 	// Info returns the current info information of the plugin.
 	Info(context.Context) (*PluginInfo, error)
 
+	HydrateOpts(context.Context, interface{}) error
+
 	// Layout runs the plugin's autolayout algorithm on the input graph
 	// and returns a new graph with the computed placements.
 	Layout(context.Context, *d2graph.Graph) error

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -32,7 +32,7 @@ type Plugin interface {
 	// Info returns the current info information of the plugin.
 	Info(context.Context) (*PluginInfo, error)
 
-	Flags() []PluginSpecificFlag
+	Flags(context.Context) ([]PluginSpecificFlag, error)
 
 	HydrateOpts([]byte) error
 
@@ -123,10 +123,14 @@ func FindPlugin(ctx context.Context, name string) (Plugin, string, error) {
 	return &execPlugin{path: path}, path, nil
 }
 
-func ListPluginFlags() []PluginSpecificFlag {
+func ListPluginFlags(ctx context.Context) ([]PluginSpecificFlag, error) {
 	var out []PluginSpecificFlag
 	for _, p := range plugins {
-		out = append(out, p.Flags()...)
+		flags, err := p.Flags(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, flags...)
 	}
-	return out
+	return out, nil
 }

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -19,11 +19,22 @@ import (
 // See plugin_* files for the plugins available for bundling.
 var plugins []Plugin
 
+type PluginSpecificFlag struct {
+	Name    string
+	Type    string
+	Default interface{}
+	Usage   string
+	// Must match the tag in the opt
+	Tag string
+}
+
 type Plugin interface {
 	// Info returns the current info information of the plugin.
 	Info(context.Context) (*PluginInfo, error)
 
-	HydrateOpts(context.Context, interface{}) error
+	Flags() []PluginSpecificFlag
+
+	HydrateOpts([]byte) error
 
 	// Layout runs the plugin's autolayout algorithm on the input graph
 	// and returns a new graph with the computed placements.
@@ -110,4 +121,12 @@ func FindPlugin(ctx context.Context, name string) (Plugin, string, error) {
 	}
 
 	return &execPlugin{path: path}, path, nil
+}
+
+func ListPluginFlags() []PluginSpecificFlag {
+	var out []PluginSpecificFlag
+	for _, p := range plugins {
+		out = append(out, p.Flags()...)
+	}
+	return out
 }

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 
 	"oss.terrastruct.com/util-go/xexec"
+	"oss.terrastruct.com/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2graph"
 )
@@ -26,6 +27,15 @@ type PluginSpecificFlag struct {
 	Usage   string
 	// Must match the tag in the opt
 	Tag string
+}
+
+func (f *PluginSpecificFlag) AddToOpts(opts *xmain.Opts) {
+	switch f.Type {
+	case "string":
+		opts.String("", f.Name, "", f.Default.(string), f.Usage)
+	case "int64":
+		opts.Int64("", f.Name, "", f.Default.(int64), f.Usage)
+	}
 }
 
 type Plugin interface {

--- a/d2plugin/plugin_dagre.go
+++ b/d2plugin/plugin_dagre.go
@@ -21,7 +21,7 @@ type dagrePlugin struct {
 	opts *d2dagrelayout.Opts
 }
 
-func (p dagrePlugin) Flags() []PluginSpecificFlag {
+func (p dagrePlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
 	return []PluginSpecificFlag{
 		{
 			Name:    "dagre-nodesep",
@@ -37,7 +37,7 @@ func (p dagrePlugin) Flags() []PluginSpecificFlag {
 			Usage:   "number of pixels that separate edges horizontally.",
 			Tag:     "edgesep",
 		},
-	}
+	}, nil
 }
 
 func (p *dagrePlugin) HydrateOpts(opts []byte) error {

--- a/d2plugin/plugin_dagre.go
+++ b/d2plugin/plugin_dagre.go
@@ -4,6 +4,7 @@ package d2plugin
 
 import (
 	"context"
+	"encoding/json"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
@@ -20,10 +21,30 @@ type dagrePlugin struct {
 	opts *d2dagrelayout.Opts
 }
 
-func (p *dagrePlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
+func (p dagrePlugin) Flags() []PluginSpecificFlag {
+	return []PluginSpecificFlag{
+		{
+			Name:    "dagre-nodesep",
+			Type:    "int64",
+			Default: int64(d2dagrelayout.DefaultOpts.NodeSep),
+			Usage:   "number of pixels that separate nodes horizontally.",
+			Tag:     "nodesep",
+		},
+		{
+			Name:    "dagre-edgesep",
+			Type:    "int64",
+			Default: int64(d2dagrelayout.DefaultOpts.EdgeSep),
+			Usage:   "number of pixels that separate edges horizontally.",
+			Tag:     "edgesep",
+		},
+	}
+}
+
+func (p *dagrePlugin) HydrateOpts(opts []byte) error {
 	if opts != nil {
-		dagreOpts, ok := opts.(d2dagrelayout.Opts)
-		if !ok {
+		var dagreOpts d2dagrelayout.Opts
+		err := json.Unmarshal(opts, &dagreOpts)
+		if err != nil {
 			return xmain.UsageErrorf("non-dagre layout options given for dagre")
 		}
 

--- a/d2plugin/plugin_dagre.go
+++ b/d2plugin/plugin_dagre.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 type dagrePlugin struct {
-	opts *d2dagrelayout.Opts
+	opts *d2dagrelayout.ConfigurableOpts
 }
 
 func (p dagrePlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
@@ -42,7 +42,7 @@ func (p dagrePlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
 
 func (p *dagrePlugin) HydrateOpts(opts []byte) error {
 	if opts != nil {
-		var dagreOpts d2dagrelayout.Opts
+		var dagreOpts d2dagrelayout.ConfigurableOpts
 		err := json.Unmarshal(opts, &dagreOpts)
 		if err != nil {
 			return xmain.UsageErrorf("non-dagre layout options given for dagre")

--- a/d2plugin/plugin_dagre.go
+++ b/d2plugin/plugin_dagre.go
@@ -5,6 +5,7 @@ package d2plugin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
@@ -53,18 +54,27 @@ func (p *dagrePlugin) HydrateOpts(opts []byte) error {
 	return nil
 }
 
-func (p dagrePlugin) Info(context.Context) (*PluginInfo, error) {
+func (p dagrePlugin) Info(ctx context.Context) (*PluginInfo, error) {
+	opts := xmain.NewOpts(nil, nil, nil)
+	flags, err := p.Flags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range flags {
+		f.AddToOpts(opts)
+	}
+
 	return &PluginInfo{
 		Name:      "dagre",
 		ShortHelp: "The directed graph layout library Dagre",
-		LongHelp: `dagre is a directed graph layout library for JavaScript.
+		LongHelp: fmt.Sprintf(`dagre is a directed graph layout library for JavaScript.
 See https://github.com/dagrejs/dagre
-The implementation of this plugin is at: https://github.com/terrastruct/d2/tree/master/d2plugin/d2dagrelayout
 
-note: dagre is the primary layout algorithm for text to diagram generator Mermaid.js.
-      See https://github.com/mermaid-js/mermaid
-      We have a useful comparison at https://text-to-diagram.com/?example=basic&a=d2&b=mermaid
-`,
+Flags correspond to ones found at https://github.com/dagrejs/dagre/wiki. See dagre's reference for more on each.
+
+Flags:
+%s
+`, opts.Defaults()),
 	}, nil
 }
 

--- a/d2plugin/plugin_dagre.go
+++ b/d2plugin/plugin_dagre.go
@@ -7,15 +7,30 @@ import (
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
+	"oss.terrastruct.com/util-go/xmain"
 )
 
 var DagrePlugin = dagrePlugin{}
 
 func init() {
-	plugins = append(plugins, DagrePlugin)
+	plugins = append(plugins, &DagrePlugin)
 }
 
-type dagrePlugin struct{}
+type dagrePlugin struct {
+	opts *d2dagrelayout.Opts
+}
+
+func (p *dagrePlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
+	if opts != nil {
+		dagreOpts, ok := opts.(d2dagrelayout.Opts)
+		if !ok {
+			return xmain.UsageErrorf("non-dagre layout options given for dagre")
+		}
+
+		p.opts = &dagreOpts
+	}
+	return nil
+}
 
 func (p dagrePlugin) Info(context.Context) (*PluginInfo, error) {
 	return &PluginInfo{
@@ -33,7 +48,7 @@ note: dagre is the primary layout algorithm for text to diagram generator Mermai
 }
 
 func (p dagrePlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
-	return d2dagrelayout.Layout(ctx, g)
+	return d2dagrelayout.Layout(ctx, g, p.opts)
 }
 
 func (p dagrePlugin) PostProcess(ctx context.Context, in []byte) ([]byte, error) {

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -22,27 +22,41 @@ type elkPlugin struct {
 }
 
 func (p elkPlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
-	// ms.Opts.String("", "elk-algorithm", "", d2elklayout.DefaultOpts.Algorithm, "number of pixels that separate nodes horizontally.")
-	//   _, err = ms.Opts.Int64("", "elk-nodeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.NodeSpacing), "number of pixels that separate edges horizontally.")
-	//   if err != nil {
-	//     return err
-	//   }
-	//   ms.Opts.String("", "elk-padding", "", d2elklayout.DefaultOpts.Padding, "number of pixels that separate nodes horizontally.")
-	//   _, err = ms.Opts.Int64("", "elk-edgeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.EdgeNodeSpacing), "number of pixels that separate edges horizontally.")
-	//   if err != nil {
-	//     return err
-	//   }
-	//   _, err = ms.Opts.Int64("", "elk-nodeSelfLoop", "", int64(d2elklayout.DefaultOpts.SelfLoopSpacing), "number of pixels that separate edges horizontally.")
-	//   if err != nil {
-	//     return err
-	//   }
 	return []PluginSpecificFlag{
 		{
 			Name:    "elk-algorithm",
 			Type:    "string",
 			Default: d2elklayout.DefaultOpts.Algorithm,
-			Usage:   "number of pixels that separate nodes horizontally.",
+			Usage:   "layout algorithm. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-algorithm.html",
 			Tag:     "elk.algorithm",
+		},
+		{
+			Name:    "elk-nodeNodeBetweenLayers",
+			Type:    "int64",
+			Default: d2elklayout.DefaultOpts.NodeSpacing,
+			Usage:   "the spacing to be preserved between any pair of nodes of two adjacent layers. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-layered-spacing-nodeNodeBetweenLayers.html",
+			Tag:     "spacing.nodeNodeBetweenLayers",
+		},
+		{
+			Name:    "elk-padding",
+			Type:    "string",
+			Default: d2elklayout.DefaultOpts.Padding,
+			Usage:   "the padding to be left to a parent element’s border when placing child elements. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-padding.html",
+			Tag:     "elk.padding",
+		},
+		{
+			Name:    "elk-edgeNodeBetweenLayers",
+			Type:    "int64",
+			Default: d2elklayout.DefaultOpts.EdgeNodeSpacing,
+			Usage:   "the spacing to be preserved between nodes and edges that are routed next to the node’s layer. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-layered-spacing-edgeNodeBetweenLayers.html",
+			Tag:     "spacing.edgeNodeBetweenLayers",
+		},
+		{
+			Name:    "elk-nodeSelfLoop",
+			Type:    "int64",
+			Default: d2elklayout.DefaultOpts.SelfLoopSpacing,
+			Usage:   "spacing to be preserved between a node and its self loops. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-spacing-nodeSelfLoop.html",
+			Tag:     "elk.spacing.nodeSelfLoop",
 		},
 	}, nil
 }

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -5,6 +5,7 @@ package d2plugin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
@@ -27,35 +28,35 @@ func (p elkPlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
 			Name:    "elk-algorithm",
 			Type:    "string",
 			Default: d2elklayout.DefaultOpts.Algorithm,
-			Usage:   "layout algorithm. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-algorithm.html",
+			Usage:   "layout algorithm",
 			Tag:     "elk.algorithm",
 		},
 		{
 			Name:    "elk-nodeNodeBetweenLayers",
 			Type:    "int64",
 			Default: int64(d2elklayout.DefaultOpts.NodeSpacing),
-			Usage:   "the spacing to be preserved between any pair of nodes of two adjacent layers. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-layered-spacing-nodeNodeBetweenLayers.html",
+			Usage:   "the spacing to be preserved between any pair of nodes of two adjacent layers",
 			Tag:     "spacing.nodeNodeBetweenLayers",
 		},
 		{
 			Name:    "elk-padding",
 			Type:    "string",
 			Default: d2elklayout.DefaultOpts.Padding,
-			Usage:   "the padding to be left to a parent element’s border when placing child elements. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-padding.html",
+			Usage:   "the padding to be left to a parent element’s border when placing child elements",
 			Tag:     "elk.padding",
 		},
 		{
 			Name:    "elk-edgeNodeBetweenLayers",
 			Type:    "int64",
 			Default: int64(d2elklayout.DefaultOpts.EdgeNodeSpacing),
-			Usage:   "the spacing to be preserved between nodes and edges that are routed next to the node’s layer. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-layered-spacing-edgeNodeBetweenLayers.html",
+			Usage:   "the spacing to be preserved between nodes and edges that are routed next to the node’s layer",
 			Tag:     "spacing.edgeNodeBetweenLayers",
 		},
 		{
 			Name:    "elk-nodeSelfLoop",
 			Type:    "int64",
 			Default: int64(d2elklayout.DefaultOpts.SelfLoopSpacing),
-			Usage:   "spacing to be preserved between a node and its self loops. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-spacing-nodeSelfLoop.html",
+			Usage:   "spacing to be preserved between a node and its self loops",
 			Tag:     "elk.spacing.nodeSelfLoop",
 		},
 	}, nil
@@ -75,13 +76,27 @@ func (p *elkPlugin) HydrateOpts(opts []byte) error {
 	return nil
 }
 
-func (p elkPlugin) Info(context.Context) (*PluginInfo, error) {
+func (p elkPlugin) Info(ctx context.Context) (*PluginInfo, error) {
+	opts := xmain.NewOpts(nil, nil, nil)
+	flags, err := p.Flags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range flags {
+		f.AddToOpts(opts)
+	}
 	return &PluginInfo{
 		Name:      "elk",
 		ShortHelp: "Eclipse Layout Kernel (ELK) with the Layered algorithm.",
-		LongHelp: `ELK is a layout engine offered by Eclipse.
+		LongHelp: fmt.Sprintf(`ELK is a layout engine offered by Eclipse.
 Originally written in Java, it has been ported to Javascript and cross-compiled into D2.
-See https://github.com/kieler/elkjs for more.`,
+See https://github.com/kieler/elkjs for more.
+
+Flags correspond to ones found in https://www.eclipse.org/elk/reference.html. See ELK's reference for more on each.
+
+Flags:
+%s
+`, opts.Defaults()),
 	}, nil
 }
 

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -67,8 +67,7 @@ func (p *elkPlugin) HydrateOpts(opts []byte) error {
 		var elkOpts d2elklayout.ConfigurableOpts
 		err := json.Unmarshal(opts, &elkOpts)
 		if err != nil {
-			// TODO not right
-			return xmain.UsageErrorf("non-dagre layout options given for dagre")
+			return xmain.UsageErrorf("non-ELK layout options given for ELK")
 		}
 
 		p.opts = &elkOpts

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -21,7 +21,7 @@ type elkPlugin struct {
 	opts *d2elklayout.ConfigurableOpts
 }
 
-func (p elkPlugin) Flags() []PluginSpecificFlag {
+func (p elkPlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
 	// ms.Opts.String("", "elk-algorithm", "", d2elklayout.DefaultOpts.Algorithm, "number of pixels that separate nodes horizontally.")
 	//   _, err = ms.Opts.Int64("", "elk-nodeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.NodeSpacing), "number of pixels that separate edges horizontally.")
 	//   if err != nil {
@@ -44,7 +44,7 @@ func (p elkPlugin) Flags() []PluginSpecificFlag {
 			Usage:   "number of pixels that separate nodes horizontally.",
 			Tag:     "elk.algorithm",
 		},
-	}
+	}, nil
 }
 
 func (p *elkPlugin) HydrateOpts(opts []byte) error {

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -92,7 +92,7 @@ func (p elkPlugin) Info(ctx context.Context) (*PluginInfo, error) {
 Originally written in Java, it has been ported to Javascript and cross-compiled into D2.
 See https://github.com/kieler/elkjs for more.
 
-Flags correspond to ones found in https://www.eclipse.org/elk/reference.html. See ELK's reference for more on each.
+Flags correspond to ones found at https://www.eclipse.org/elk/reference.html. See ELK's reference for more on each.
 
 Flags:
 %s

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -13,16 +13,16 @@ import (
 var ELKPlugin = elkPlugin{}
 
 func init() {
-	plugins = append(plugins, ELKPlugin)
+	plugins = append(plugins, &ELKPlugin)
 }
 
 type elkPlugin struct {
-	opts *d2elklayout.ELKLayoutOptions
+	opts *d2elklayout.ConfigurableOpts
 }
 
-func (p elkPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
+func (p *elkPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
 	if opts != nil {
-		elkOpts, ok := opts.(d2elklayout.ELKLayoutOptions)
+		elkOpts, ok := opts.(d2elklayout.ConfigurableOpts)
 		if !ok {
 			return xmain.UsageErrorf("non-dagre layout options given for dagre")
 		}
@@ -32,7 +32,7 @@ func (p elkPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
 	return nil
 }
 
-func (p elkPlugin) Info(context.Context) (*PluginInfo, error) {
+func (p *elkPlugin) Info(context.Context) (*PluginInfo, error) {
 	return &PluginInfo{
 		Name:      "elk",
 		ShortHelp: "Eclipse Layout Kernel (ELK) with the Layered algorithm.",
@@ -42,10 +42,10 @@ See https://github.com/kieler/elkjs for more.`,
 	}, nil
 }
 
-func (p elkPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
+func (p *elkPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
 	return d2elklayout.Layout(ctx, g, p.opts)
 }
 
-func (p elkPlugin) PostProcess(ctx context.Context, in []byte) ([]byte, error) {
+func (p *elkPlugin) PostProcess(ctx context.Context, in []byte) ([]byte, error) {
 	return in, nil
 }

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -33,7 +33,7 @@ func (p elkPlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
 		{
 			Name:    "elk-nodeNodeBetweenLayers",
 			Type:    "int64",
-			Default: d2elklayout.DefaultOpts.NodeSpacing,
+			Default: int64(d2elklayout.DefaultOpts.NodeSpacing),
 			Usage:   "the spacing to be preserved between any pair of nodes of two adjacent layers. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-layered-spacing-nodeNodeBetweenLayers.html",
 			Tag:     "spacing.nodeNodeBetweenLayers",
 		},
@@ -47,14 +47,14 @@ func (p elkPlugin) Flags(context.Context) ([]PluginSpecificFlag, error) {
 		{
 			Name:    "elk-edgeNodeBetweenLayers",
 			Type:    "int64",
-			Default: d2elklayout.DefaultOpts.EdgeNodeSpacing,
+			Default: int64(d2elklayout.DefaultOpts.EdgeNodeSpacing),
 			Usage:   "the spacing to be preserved between nodes and edges that are routed next to the node’s layer. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-layered-spacing-edgeNodeBetweenLayers.html",
 			Tag:     "spacing.edgeNodeBetweenLayers",
 		},
 		{
 			Name:    "elk-nodeSelfLoop",
 			Type:    "int64",
-			Default: d2elklayout.DefaultOpts.SelfLoopSpacing,
+			Default: int64(d2elklayout.DefaultOpts.SelfLoopSpacing),
 			Usage:   "spacing to be preserved between a node and its self loops. https://www.eclipse.org/elk/reference/options/org-eclipse-elk-spacing-nodeSelfLoop.html",
 			Tag:     "elk.spacing.nodeSelfLoop",
 		},

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -7,6 +7,7 @@ import (
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
+	"oss.terrastruct.com/util-go/xmain"
 )
 
 var ELKPlugin = elkPlugin{}
@@ -15,7 +16,21 @@ func init() {
 	plugins = append(plugins, ELKPlugin)
 }
 
-type elkPlugin struct{}
+type elkPlugin struct {
+	opts *d2elklayout.ELKLayoutOptions
+}
+
+func (p elkPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
+	if opts != nil {
+		elkOpts, ok := opts.(d2elklayout.ELKLayoutOptions)
+		if !ok {
+			return xmain.UsageErrorf("non-dagre layout options given for dagre")
+		}
+
+		p.opts = &elkOpts
+	}
+	return nil
+}
 
 func (p elkPlugin) Info(context.Context) (*PluginInfo, error) {
 	return &PluginInfo{
@@ -28,7 +43,7 @@ See https://github.com/kieler/elkjs for more.`,
 }
 
 func (p elkPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
-	return d2elklayout.Layout(ctx, g)
+	return d2elklayout.Layout(ctx, g, p.opts)
 }
 
 func (p elkPlugin) PostProcess(ctx context.Context, in []byte) ([]byte, error) {

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -4,6 +4,7 @@ package d2plugin
 
 import (
 	"context"
+	"encoding/json"
 
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
@@ -20,10 +21,38 @@ type elkPlugin struct {
 	opts *d2elklayout.ConfigurableOpts
 }
 
-func (p *elkPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
+func (p elkPlugin) Flags() []PluginSpecificFlag {
+	// ms.Opts.String("", "elk-algorithm", "", d2elklayout.DefaultOpts.Algorithm, "number of pixels that separate nodes horizontally.")
+	//   _, err = ms.Opts.Int64("", "elk-nodeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.NodeSpacing), "number of pixels that separate edges horizontally.")
+	//   if err != nil {
+	//     return err
+	//   }
+	//   ms.Opts.String("", "elk-padding", "", d2elklayout.DefaultOpts.Padding, "number of pixels that separate nodes horizontally.")
+	//   _, err = ms.Opts.Int64("", "elk-edgeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.EdgeNodeSpacing), "number of pixels that separate edges horizontally.")
+	//   if err != nil {
+	//     return err
+	//   }
+	//   _, err = ms.Opts.Int64("", "elk-nodeSelfLoop", "", int64(d2elklayout.DefaultOpts.SelfLoopSpacing), "number of pixels that separate edges horizontally.")
+	//   if err != nil {
+	//     return err
+	//   }
+	return []PluginSpecificFlag{
+		{
+			Name:    "elk-algorithm",
+			Type:    "string",
+			Default: d2elklayout.DefaultOpts.Algorithm,
+			Usage:   "number of pixels that separate nodes horizontally.",
+			Tag:     "elk.algorithm",
+		},
+	}
+}
+
+func (p *elkPlugin) HydrateOpts(opts []byte) error {
 	if opts != nil {
-		elkOpts, ok := opts.(d2elklayout.ConfigurableOpts)
-		if !ok {
+		var elkOpts d2elklayout.ConfigurableOpts
+		err := json.Unmarshal(opts, &elkOpts)
+		if err != nil {
+			// TODO not right
 			return xmain.UsageErrorf("non-dagre layout options given for dagre")
 		}
 
@@ -32,7 +61,7 @@ func (p *elkPlugin) HydrateOpts(ctx context.Context, opts interface{}) error {
 	return nil
 }
 
-func (p *elkPlugin) Info(context.Context) (*PluginInfo, error) {
+func (p elkPlugin) Info(context.Context) (*PluginInfo, error) {
 	return &PluginInfo{
 		Name:      "elk",
 		ShortHelp: "Eclipse Layout Kernel (ELK) with the Layered algorithm.",
@@ -42,10 +71,10 @@ See https://github.com/kieler/elkjs for more.`,
 	}, nil
 }
 
-func (p *elkPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
+func (p elkPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
 	return d2elklayout.Layout(ctx, g, p.opts)
 }
 
-func (p *elkPlugin) PostProcess(ctx context.Context, in []byte) ([]byte, error) {
+func (p elkPlugin) PostProcess(ctx context.Context, in []byte) ([]byte, error) {
 	return in, nil
 }

--- a/d2plugin/serve.go
+++ b/d2plugin/serve.go
@@ -38,6 +38,8 @@ func Serve(p Plugin) xmain.RunFunc {
 		switch subcmd {
 		case "info":
 			return info(ctx, p, ms)
+		case "flags":
+			return flags(ctx, p, ms)
 		case "layout":
 			return layout(ctx, p, ms)
 		case "postprocess":
@@ -54,6 +56,22 @@ func info(ctx context.Context, p Plugin, ms *xmain.State) error {
 		return err
 	}
 	b, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	_, err = ms.Stdout.Write(b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func flags(ctx context.Context, p Plugin, ms *xmain.State) error {
+	flags, err := p.Flags(ctx)
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(flags)
 	if err != nil {
 		return err
 	}

--- a/d2renderers/d2sketch/sketch_test.go
+++ b/d2renderers/d2sketch/sketch_test.go
@@ -314,7 +314,7 @@ func run(t *testing.T, tc testCase) {
 	diagram, _, err := d2lib.Compile(ctx, tc.script, &d2lib.CompileOptions{
 		Ruler:      ruler,
 		ThemeID:    0,
-		Layout:     d2dagrelayout.Layout,
+		Layout:     d2dagrelayout.DefaultLayout,
 		FontFamily: go2.Pointer(d2fonts.HandDrawn),
 	})
 	if !tassert.Nil(t, err) {

--- a/d2renderers/d2svg/appendix/appendix_test.go
+++ b/d2renderers/d2svg/appendix/appendix_test.go
@@ -121,7 +121,7 @@ func run(t *testing.T, tc testCase) {
 	diagram, _, err := d2lib.Compile(ctx, tc.script, &d2lib.CompileOptions{
 		Ruler:   ruler,
 		ThemeID: 0,
-		Layout:  d2dagrelayout.Layout,
+		Layout:  d2dagrelayout.DefaultLayout,
 	})
 	if !tassert.Nil(t, err) {
 		return

--- a/docs/examples/lib/1-d2lib/d2lib.go
+++ b/docs/examples/lib/1-d2lib/d2lib.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
 	"oss.terrastruct.com/d2/d2lib"
 	"oss.terrastruct.com/d2/d2renderers/d2svg"
@@ -15,8 +16,11 @@ import (
 // Remember to add if err != nil checks in production.
 func main() {
 	ruler, _ := textmeasure.NewRuler()
+	defaultLayout := func(ctx context.Context, g *d2graph.Graph) error {
+		return d2dagrelayout.Layout(ctx, g, nil)
+	}
 	diagram, _, _ := d2lib.Compile(context.Background(), "x -> y", &d2lib.CompileOptions{
-		Layout:  d2dagrelayout.Layout,
+		Layout:  defaultLayout,
 		Ruler:   ruler,
 		ThemeID: d2themescatalog.GrapeSoda.ID,
 	})

--- a/docs/examples/lib/2-d2oracle/d2oracle.go
+++ b/docs/examples/lib/2-d2oracle/d2oracle.go
@@ -17,7 +17,7 @@ func main() {
 	// From one.go
 	ruler, _ := textmeasure.NewRuler()
 	_, graph, _ := d2lib.Compile(context.Background(), "x -> y", &d2lib.CompileOptions{
-		Layout:  d2dagrelayout.Layout,
+		Layout:  d2dagrelayout.DefaultLayout,
 		Ruler:   ruler,
 		ThemeID: d2themescatalog.GrapeSoda.ID,
 	})

--- a/docs/examples/lib/3-lowlevel/lowlevel.go
+++ b/docs/examples/lib/3-lowlevel/lowlevel.go
@@ -19,7 +19,7 @@ func main() {
 	graph, _ := d2compiler.Compile("", strings.NewReader("x -> y"), nil)
 	ruler, _ := textmeasure.NewRuler()
 	_ = graph.SetDimensions(nil, ruler, nil)
-	_ = d2dagrelayout.Layout(context.Background(), graph)
+	_ = d2dagrelayout.Layout(context.Background(), graph, nil)
 	diagram, _ := d2exporter.Export(context.Background(), graph, d2themescatalog.NeutralDefault.ID, nil)
 	out, _ := d2svg.Render(diagram, &d2svg.RenderOpts{
 		Pad: d2svg.DEFAULT_PADDING,

--- a/e2etests/e2e_test.go
+++ b/e2etests/e2e_test.go
@@ -130,9 +130,9 @@ func run(t *testing.T, tc testCase) {
 	for _, layoutName := range layoutsTested {
 		var layout func(context.Context, *d2graph.Graph) error
 		if layoutName == "dagre" {
-			layout = d2dagrelayout.Layout
+			layout = d2dagrelayout.DefaultLayout
 		} else if layoutName == "elk" {
-			layout = d2elklayout.Layout
+			layout = d2elklayout.DefaultLayout
 		}
 		diagram, _, err := d2lib.Compile(ctx, tc.script, &d2lib.CompileOptions{
 			Ruler:   ruler,

--- a/help.go
+++ b/help.go
@@ -32,7 +32,7 @@ Flags:
 
 Subcommands:
   %[1]s layout - Lists available layout engine options with short help
-  %[1]s layout [name] - Display long help for a particular layout engine
+  %[1]s layout [name] - Display long help for a particular layout engine, including its configuration options
   %[1]s fmt file.d2 - Format file.d2
 
 See more docs and the source code at https://oss.terrastruct.com/d2
@@ -75,7 +75,7 @@ Example:
   D2_LAYOUT=dagre d2 in.d2 out.svg
 
 Subcommands:
-  %s layout [layout name] - Display long help for a particular layout engine
+  %s layout [layout name] - Display long help for a particular layout engine, including its configuration options
 
 See more docs at https://oss.terrastruct.com/d2
 `, strings.Join(pluginLines, "\n"), ms.Name)

--- a/main.go
+++ b/main.go
@@ -342,31 +342,4 @@ func parseLayoutOpts(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugi
 
 	err = plugin.HydrateOpts(b)
 	return err
-
-	// switch layout {
-	// case "dagre":
-	//   nodesep, _ := ms.Opts.Flags.GetInt64("dagre-nodesep")
-	//   edgesep, _ := ms.Opts.Flags.GetInt64("dagre-edgesep")
-	//   return d2dagrelayout.Opts{
-	//     NodeSep: int(nodesep),
-	//     EdgeSep: int(edgesep),
-	//   }, nil
-	// case "elk":
-	//   algorithm, _ := ms.Opts.Flags.GetString("elk-algorithm")
-	//   nodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeNodeBetweenLayers")
-	//   padding, _ := ms.Opts.Flags.GetString("elk-padding")
-	//   edgeNodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-edgeNodeSpacing")
-	//   selfLoopSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeSelfLoop")
-	//   return d2elklayout.ConfigurableOpts{
-	//     Algorithm:       algorithm,
-	//     NodeSpacing:     int(nodeSpacing),
-	//     Padding:         padding,
-	//     EdgeNodeSpacing: int(edgeNodeSpacing),
-	//     SelfLoopSpacing: int(selfLoopSpacing),
-	//   }, nil
-	// default:
-	//
-	// }
-	//
-	// return nil, fmt.Errorf("unexpected error, layout not found for parsing opts")
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"oss.terrastruct.com/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
+	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
 	"oss.terrastruct.com/d2/d2lib"
 	"oss.terrastruct.com/d2/d2plugin"
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"
@@ -306,18 +307,54 @@ func DiscardSlog(ctx context.Context) context.Context {
 }
 
 func populateLayoutOpts(ms *xmain.State) error {
-	_, err := ms.Opts.Int64("", "dagre-nodesep", "", int64(d2dagrelayout.DefaultOpts.NodeSep), "number of pixels that separate nodes horizontally in the layout.")
+	_, err := ms.Opts.Int64("", "dagre-nodesep", "", int64(d2dagrelayout.DefaultOpts.NodeSep), "number of pixels that separate nodes horizontally.")
 	if err != nil {
 		return err
 	}
+	_, err = ms.Opts.Int64("", "dagre-edgesep", "", int64(d2dagrelayout.DefaultOpts.EdgeSep), "number of pixels that separate edges horizontally.")
+	if err != nil {
+		return err
+	}
+
+	ms.Opts.String("", "elk-algorithm", "", d2elklayout.DefaultOpts.Algorithm, "number of pixels that separate nodes horizontally.")
+	_, err = ms.Opts.Int64("", "elk-nodeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.NodeSpacing), "number of pixels that separate edges horizontally.")
+	if err != nil {
+		return err
+	}
+	ms.Opts.String("", "elk-padding", "", d2elklayout.DefaultOpts.Padding, "number of pixels that separate nodes horizontally.")
+	_, err = ms.Opts.Int64("", "elk-edgeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.EdgeNodeSpacing), "number of pixels that separate edges horizontally.")
+	if err != nil {
+		return err
+	}
+	_, err = ms.Opts.Int64("", "elk-nodeSelfLoop", "", int64(d2elklayout.DefaultOpts.SelfLoopSpacing), "number of pixels that separate edges horizontally.")
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func parseLayoutOpts(ms *xmain.State, layout string) (interface{}, error) {
-	if layout == "dagre" {
+	switch layout {
+	case "dagre":
 		nodesep, _ := ms.Opts.Flags.GetInt64("dagre-nodesep")
+		edgesep, _ := ms.Opts.Flags.GetInt64("dagre-edgesep")
 		return d2dagrelayout.Opts{
 			NodeSep: int(nodesep),
+			EdgeSep: int(edgesep),
+		}, nil
+	case "elk":
+		algorithm, _ := ms.Opts.Flags.GetString("elk-algorithm")
+		nodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeNodeBetweenLayers")
+		padding, _ := ms.Opts.Flags.GetString("elk-padding")
+		edgeNodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-edgeNodeSpacing")
+		selfLoopSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeSelfLoop")
+		return d2elklayout.ConfigurableOpts{
+			Algorithm:       algorithm,
+			NodeSpacing:     int(nodeSpacing),
+			Padding:         padding,
+			EdgeNodeSpacing: int(edgeNodeSpacing),
+			SelfLoopSpacing: int(selfLoopSpacing),
 		}, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -307,12 +307,9 @@ func populateLayoutOpts(ctx context.Context, ms *xmain.State) error {
 	}
 
 	for _, f := range pluginFlags {
-		switch f.Type {
-		case "string":
-			ms.Opts.String("", f.Name, "", f.Default.(string), f.Usage)
-		case "int64":
-			ms.Opts.Int64("", f.Name, "", f.Default.(int64), f.Usage)
-		}
+		f.AddToOpts(ms.Opts)
+		// Don't pollute the main d2 flagset with these. It'll be a lot
+		ms.Opts.Flags.MarkHidden(f.Name)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func run(ctx context.Context, ms *xmain.State) (err error) {
 		return err
 	}
 
-	err = populateLayoutOpts(ms)
+	err = populateLayoutOpts(ctx, ms)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func run(ctx context.Context, ms *xmain.State) (err error) {
 		return err
 	}
 
-	err = parseLayoutOpts(ms, plugin)
+	err = parseLayoutOpts(ctx, ms, plugin)
 	if err != nil {
 		return err
 	}
@@ -300,8 +300,11 @@ func DiscardSlog(ctx context.Context) context.Context {
 	return ctxlog.With(ctx, slog.Make(sloghuman.Sink(io.Discard)))
 }
 
-func populateLayoutOpts(ms *xmain.State) error {
-	pluginFlags := d2plugin.ListPluginFlags()
+func populateLayoutOpts(ctx context.Context, ms *xmain.State) error {
+	pluginFlags, err := d2plugin.ListPluginFlags(ctx)
+	if err != nil {
+		return err
+	}
 
 	for _, f := range pluginFlags {
 		switch f.Type {
@@ -315,9 +318,13 @@ func populateLayoutOpts(ms *xmain.State) error {
 	return nil
 }
 
-func parseLayoutOpts(ms *xmain.State, plugin d2plugin.Plugin) error {
+func parseLayoutOpts(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin) error {
 	opts := make(map[string]interface{})
-	for _, f := range plugin.Flags() {
+	flags, err := plugin.Flags(ctx)
+	if err != nil {
+		return err
+	}
+	for _, f := range flags {
 		switch f.Type {
 		case "string":
 			val, _ := ms.Opts.Flags.GetString(f.Name)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,8 +18,6 @@ import (
 	"oss.terrastruct.com/util-go/go2"
 	"oss.terrastruct.com/util-go/xmain"
 
-	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
-	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
 	"oss.terrastruct.com/d2/d2lib"
 	"oss.terrastruct.com/d2/d2plugin"
 	"oss.terrastruct.com/d2/d2renderers/d2fonts"
@@ -151,12 +150,7 @@ func run(ctx context.Context, ms *xmain.State) (err error) {
 		return err
 	}
 
-	layoutOpts, err := parseLayoutOpts(ms, *layoutFlag)
-	if err != nil {
-		return err
-	}
-
-	err = plugin.HydrateOpts(ctx, layoutOpts)
+	err = parseLayoutOpts(ms, plugin)
 	if err != nil {
 		return err
 	}
@@ -307,56 +301,65 @@ func DiscardSlog(ctx context.Context) context.Context {
 }
 
 func populateLayoutOpts(ms *xmain.State) error {
-	_, err := ms.Opts.Int64("", "dagre-nodesep", "", int64(d2dagrelayout.DefaultOpts.NodeSep), "number of pixels that separate nodes horizontally.")
-	if err != nil {
-		return err
-	}
-	_, err = ms.Opts.Int64("", "dagre-edgesep", "", int64(d2dagrelayout.DefaultOpts.EdgeSep), "number of pixels that separate edges horizontally.")
-	if err != nil {
-		return err
-	}
+	pluginFlags := d2plugin.ListPluginFlags()
 
-	ms.Opts.String("", "elk-algorithm", "", d2elklayout.DefaultOpts.Algorithm, "number of pixels that separate nodes horizontally.")
-	_, err = ms.Opts.Int64("", "elk-nodeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.NodeSpacing), "number of pixels that separate edges horizontally.")
-	if err != nil {
-		return err
-	}
-	ms.Opts.String("", "elk-padding", "", d2elklayout.DefaultOpts.Padding, "number of pixels that separate nodes horizontally.")
-	_, err = ms.Opts.Int64("", "elk-edgeNodeBetweenLayers", "", int64(d2elklayout.DefaultOpts.EdgeNodeSpacing), "number of pixels that separate edges horizontally.")
-	if err != nil {
-		return err
-	}
-	_, err = ms.Opts.Int64("", "elk-nodeSelfLoop", "", int64(d2elklayout.DefaultOpts.SelfLoopSpacing), "number of pixels that separate edges horizontally.")
-	if err != nil {
-		return err
+	for _, f := range pluginFlags {
+		switch f.Type {
+		case "string":
+			ms.Opts.String("", f.Name, "", f.Default.(string), f.Usage)
+		case "int64":
+			ms.Opts.Int64("", f.Name, "", f.Default.(int64), f.Usage)
+		}
 	}
 
 	return nil
 }
 
-func parseLayoutOpts(ms *xmain.State, layout string) (interface{}, error) {
-	switch layout {
-	case "dagre":
-		nodesep, _ := ms.Opts.Flags.GetInt64("dagre-nodesep")
-		edgesep, _ := ms.Opts.Flags.GetInt64("dagre-edgesep")
-		return d2dagrelayout.Opts{
-			NodeSep: int(nodesep),
-			EdgeSep: int(edgesep),
-		}, nil
-	case "elk":
-		algorithm, _ := ms.Opts.Flags.GetString("elk-algorithm")
-		nodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeNodeBetweenLayers")
-		padding, _ := ms.Opts.Flags.GetString("elk-padding")
-		edgeNodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-edgeNodeSpacing")
-		selfLoopSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeSelfLoop")
-		return d2elklayout.ConfigurableOpts{
-			Algorithm:       algorithm,
-			NodeSpacing:     int(nodeSpacing),
-			Padding:         padding,
-			EdgeNodeSpacing: int(edgeNodeSpacing),
-			SelfLoopSpacing: int(selfLoopSpacing),
-		}, nil
+func parseLayoutOpts(ms *xmain.State, plugin d2plugin.Plugin) error {
+	opts := make(map[string]interface{})
+	for _, f := range plugin.Flags() {
+		switch f.Type {
+		case "string":
+			val, _ := ms.Opts.Flags.GetString(f.Name)
+			opts[f.Tag] = val
+		case "int64":
+			val, _ := ms.Opts.Flags.GetInt64(f.Name)
+			opts[f.Tag] = val
+		}
 	}
 
-	return nil, fmt.Errorf("unexpected error, layout not found for parsing opts")
+	b, err := json.Marshal(opts)
+	if err != nil {
+		return err
+	}
+
+	err = plugin.HydrateOpts(b)
+	return err
+
+	// switch layout {
+	// case "dagre":
+	//   nodesep, _ := ms.Opts.Flags.GetInt64("dagre-nodesep")
+	//   edgesep, _ := ms.Opts.Flags.GetInt64("dagre-edgesep")
+	//   return d2dagrelayout.Opts{
+	//     NodeSep: int(nodesep),
+	//     EdgeSep: int(edgesep),
+	//   }, nil
+	// case "elk":
+	//   algorithm, _ := ms.Opts.Flags.GetString("elk-algorithm")
+	//   nodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeNodeBetweenLayers")
+	//   padding, _ := ms.Opts.Flags.GetString("elk-padding")
+	//   edgeNodeSpacing, _ := ms.Opts.Flags.GetInt64("elk-edgeNodeSpacing")
+	//   selfLoopSpacing, _ := ms.Opts.Flags.GetInt64("elk-nodeSelfLoop")
+	//   return d2elklayout.ConfigurableOpts{
+	//     Algorithm:       algorithm,
+	//     NodeSpacing:     int(nodeSpacing),
+	//     Padding:         padding,
+	//     EdgeNodeSpacing: int(edgeNodeSpacing),
+	//     SelfLoopSpacing: int(selfLoopSpacing),
+	//   }, nil
+	// default:
+	//
+	// }
+	//
+	// return nil, fmt.Errorf("unexpected error, layout not found for parsing opts")
 }


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

![d2 (59)](https://user-images.githubusercontent.com/3120367/210113028-96a4adce-1a0c-4a10-868a-193cb06a9068.png)

Layout configs do not pollute the main flagset. They are hidden. They are shown when the command for layout help is run:

<img width="1126" alt="Screen Shot 2022-12-30 at 1 20 09 PM" src="https://user-images.githubusercontent.com/3120367/210112461-5bc21e3c-ada8-4208-8524-86d0e1bed9e3.png">

<img width="342" alt="Screen Shot 2022-12-30 at 1 26 45 PM" src="https://user-images.githubusercontent.com/3120367/210112796-366432cf-b818-4c23-a91a-cec59edf85b1.png">

![60](https://user-images.githubusercontent.com/3120367/210112789-70394bd2-aee1-4f81-a796-4e59c8886668.png)
![200](https://user-images.githubusercontent.com/3120367/210112790-5fedfd19-43c1-4935-aca9-52236edafe8f.png)

