### PR TITLE
docker: add ca-certificates package

### DIFF
--- a/ci/release/Dockerfile
+++ b/ci/release/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:latest
 
 ARG TARGETARCH
 
+RUN apt-get update && \
+      apt-get install -y ca-certificates
+
 COPY ./d2-*-linux-$TARGETARCH.tar.gz /tmp
 RUN mkdir -p /usr/local/lib/d2 \
       && tar -C /usr/local/lib/d2 -xzf /tmp/d2-*-linux-"$TARGETARCH".tar.gz \

--- a/ci/release/linux/Dockerfile
+++ b/ci/release/linux/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10
 
 RUN apt-get update
-RUN apt-get install -y curl
+RUN apt-get install -y curl ca-certificates
 
 ARG GOVERSION=
 RUN curl -fsSL "https://go.dev/dl/go$GOVERSION.tar.gz" >/tmp/go.tar.gz


### PR DESCRIPTION
fixed: https://github.com/terrastruct/d2/issues/594

```
err: failed to install Playwright: could not install driver: could not install driver: could not download driver: Get "https://playwright.azureedge.net/builds/driver/next/playwright-1.20.0-beta-1647057403000-linux.zip": x509: certificate signed by unknown authority
```