### PR TITLE
render: Support dark themes

### DIFF
--- a/d2themes/d2themes.go
+++ b/d2themes/d2themes.go
@@ -58,3 +58,13 @@ var WarmNeutral = Neutral{
 	N6: "#ECEBEB",
 	N7: "#FFFFFF",
 }
+
+var CattpuccinMochaNeutral = Neutral{
+	N1: "#cdd6f4",
+	N2: "#bac2de",
+	N3: "#a6adc8",
+	N4: "#585b70",
+	N5: "#45475a",
+	N6: "#313244",
+	N7: "#1e1e2e",
+}

--- a/d2themes/d2themescatalog/catalog.go
+++ b/d2themes/d2themescatalog/catalog.go
@@ -22,6 +22,7 @@ var Catalog = []d2themes.Theme{
 	EarthTones,
 	EvergladeGreen,
 	ButteredToast,
+	CatppuccinMochaMauve,
 }
 
 func Find(id int64) d2themes.Theme {

--- a/d2themes/d2themescatalog/catppuccin_mocha_mauve.go
+++ b/d2themes/d2themescatalog/catppuccin_mocha_mauve.go
@@ -1,0 +1,25 @@
+package d2themescatalog
+
+import "oss.terrastruct.com/d2/d2themes"
+
+var CatppuccinMochaMauve = d2themes.Theme{
+	ID:   200,
+	Name: "Catppuccin Mocha Mauve",
+	Colors: d2themes.ColorPalette{
+		Neutrals: d2themes.CattpuccinMochaNeutral,
+
+		B1: "#cba6f7",
+		B2: "#cba6f7",
+		B3: "#6c7086",
+		B4: "#585b70",
+		B5: "#45475a",
+		B6: "#313244",
+
+		AA2: "#f38ba8",
+		AA4: "#45475a",
+		AA5: "#313244",
+
+		AB4: "#45475a",
+		AB5: "#313244",
+	},
+}

--- a/main.go
+++ b/main.go
@@ -248,6 +248,7 @@ func compile(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, sketc
 	svg, err := d2svg.Render(diagram, &d2svg.RenderOpts{
 		Pad:    int(pad),
 		Sketch: sketch,
+		ThemeID: themeID,
 	})
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
Hey, I tried to create my own dark theme, but I found out there is no way to change the background. There was also hardcoded foreground color for arrow labels so I changed it to N1 (Text).

I added colors from the [Cattpuccin Mocha Mauve](https://github.com/catppuccin/catppuccin#-palettes) color scheme for testing and because it looks really nice.

Some things are still missing, Latex and code blocks render horribly, but I just wanted to share my changes. What do you all think about this?

## What is working
![Classes](https://user-images.githubusercontent.com/13472046/211078946-9a0492ca-6ed8-4812-9bfd-b1d3f5fb2a40.svg)
![Containers](https://user-images.githubusercontent.com/13472046/211078954-4be21a25-c370-4b86-8b1b-f5e408ae40b3.svg)
![Sequence](https://user-images.githubusercontent.com/13472046/211078961-768b701f-1629-4dbd-b46c-51aeed2344ec.svg)
![SQL](https://user-images.githubusercontent.com/13472046/211078963-6bc08135-6656-4d86-8189-f87e9cee12e6.svg)
![Arrows](https://user-images.githubusercontent.com/13472046/211079450-3129fdd6-5bbb-40b3-9570-7f4abd7fd2e0.svg)

## And what is not AFAIK
![Latex](https://user-images.githubusercontent.com/13472046/211078956-bb65dc46-8924-45a4-9b1e-e2a4233fc886.svg)
![Code](https://user-images.githubusercontent.com/13472046/211078951-23ea583b-fa45-4f8e-924a-368997c82a45.svg)