### PR TITLE
Rectangle and SQL Table Style: Fix border-radius for rectangles

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -11,3 +11,4 @@
 - Watch mode only fits to screen on initial load. [#601](https://github.com/terrastruct/d2/pull/601)
 - Dimensions (`width`/`height`) were incorrectly giving compiler errors when applied on a shape with style. [#614](https://github.com/terrastruct/d2/pull/614)
 - `near` would collide with labels if they were on the diagram boundaries in the same position. [#617](https://github.com/terrastruct/d2/pull/617)
+- `border-radius` having no effect on rectangles #592

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -734,8 +734,8 @@ func drawShape(writer io.Writer, targetShape d2target.Shape, sketchRunner *d2ske
 				}
 				fmt.Fprintf(writer, out)
 			} else {
-				fmt.Fprintf(writer, `<rect x="%d" y="%d" width="%d" height="%d" style="%s" />`,
-					targetShape.Pos.X, targetShape.Pos.Y, targetShape.Width, targetShape.Height, style)
+				fmt.Fprintf(writer, `<rect x="%d" y="%d" width="%d" height="%d" style="%s" rx="%d" />`,
+					targetShape.Pos.X, targetShape.Pos.Y, targetShape.Width, targetShape.Height, style, targetShape.BorderRadius)
 			}
 		}
 	case d2target.ShapeText, d2target.ShapeCode:


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->

Fix for #592 .

- 3D Cubes are unaffected
![image](https://user-images.githubusercontent.com/9019120/211116583-f57396c6-f053-4c76-91b3-32469cd822ee.png)

## TODO

- [x] Rectangles now have border radius
- [ ] Rewrite tests so they do not fail because of the new change
