### PR TITLE
cli: Make bundle option default to false

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -16,3 +16,4 @@
 - Fixes arrowheads sometimes appearing broken with sketch on. [#656](https://github.com/terrastruct/d2/pull/656)
 - Fixes code snippets not being tall enough with leading newlines. [#664](https://github.com/terrastruct/d2/pull/664)
 - Icon URLs that needed escaping (e.g. with ampersands) are handled correctly by CLI. [#666](https://github.com/terrastruct/d2/pull/666)
+- Fixes bundle CLI option not defaulting to false. [#668](https://github.com/terrastruct/d2/pull/668)

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -68,7 +68,7 @@ Pixels padded around the rendered diagram
 Set the diagram layout engine to the passed string. For a list of available options, run
 .Ar layout
 .Ns .
-.It Fl b , -bundle Ar true
+.It Fl b , -bundle Ar false
 Bundle all assets and layers into the output svg.
 .It Fl d , -debug
 Print debug logs.

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func run(ctx context.Context, ms *xmain.State) (err error) {
 	}
 	hostFlag := ms.Opts.String("HOST", "host", "h", "localhost", "host listening address when used with watch")
 	portFlag := ms.Opts.String("PORT", "port", "p", "0", "port listening address when used with watch")
-	bundleFlag, err := ms.Opts.Bool("D2_BUNDLE", "bundle", "b", true, "when outputting SVG, bundle all assets and layers into the output file")
+	bundleFlag, err := ms.Opts.Bool("D2_BUNDLE", "bundle", "b", false, "when outputting SVG, bundle all assets and layers into the output file")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If it would default to true (like it did), it could not be unset.

Should fix #667.