### PR TITLE
docs: Adding JS D2 diagram builder to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ let us know and we'll be happy to include it here!
 - **D2 org-mode support**: [https://github.com/xcapaldi/ob-d2](https://github.com/xcapaldi/ob-d2)
 - **Python D2 diagram builder**: [https://github.com/MrBlenny/py-d2](https://github.com/MrBlenny/py-d2)
 - **Clojure D2 transpiler**: [https://github.com/judepayne/dictim](https://github.com/judepayne/dictim)
+- **JavaScript D2 diagram builder**: [https://github.com/Kreshnik/d2lang-js](https://github.com/Kreshnik/d2lang-js)
 
 ### Misc
 


### PR DESCRIPTION
I have added a reference link to a Community plugins to build JavaScript D2 diagram in D2
