### PR TITLE
account for 3d offset in bounding box

### DIFF
--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -38,7 +38,6 @@ import (
 const (
 	DEFAULT_PADDING            = 100
 	MIN_ARROWHEAD_STROKE_WIDTH = 2
-	threeDeeOffset             = 15
 
 	appendixIconRadius = 16
 )
@@ -578,9 +577,9 @@ func render3dRect(targetShape d2target.Shape) string {
 		moveTo(d2target.Point{X: 0, Y: 0}),
 	)
 	for _, v := range []d2target.Point{
-		{X: threeDeeOffset, Y: -threeDeeOffset},
-		{X: targetShape.Width + threeDeeOffset, Y: -threeDeeOffset},
-		{X: targetShape.Width + threeDeeOffset, Y: targetShape.Height - threeDeeOffset},
+		{X: d2target.THREE_DEE_OFFSET, Y: -d2target.THREE_DEE_OFFSET},
+		{X: targetShape.Width + d2target.THREE_DEE_OFFSET, Y: -d2target.THREE_DEE_OFFSET},
+		{X: targetShape.Width + d2target.THREE_DEE_OFFSET, Y: targetShape.Height - d2target.THREE_DEE_OFFSET},
 		{X: targetShape.Width, Y: targetShape.Height},
 		{X: 0, Y: targetShape.Height},
 		{X: 0, Y: 0},
@@ -594,7 +593,7 @@ func render3dRect(targetShape d2target.Shape) string {
 		moveTo(d2target.Point{X: targetShape.Width, Y: 0}),
 	)
 	borderSegments = append(borderSegments,
-		lineTo(d2target.Point{X: targetShape.Width + threeDeeOffset, Y: -threeDeeOffset}),
+		lineTo(d2target.Point{X: targetShape.Width + d2target.THREE_DEE_OFFSET, Y: -d2target.THREE_DEE_OFFSET}),
 	)
 	border := targetShape
 	border.Fill = "none"
@@ -606,10 +605,10 @@ func render3dRect(targetShape d2target.Shape) string {
 	maskID := fmt.Sprintf("border-mask-%v", svg.EscapeText(targetShape.ID))
 	borderMask := strings.Join([]string{
 		fmt.Sprintf(`<defs><mask id="%s" maskUnits="userSpaceOnUse" x="%d" y="%d" width="%d" height="%d">`,
-			maskID, targetShape.Pos.X, targetShape.Pos.Y-threeDeeOffset, targetShape.Width+threeDeeOffset, targetShape.Height+threeDeeOffset,
+			maskID, targetShape.Pos.X, targetShape.Pos.Y-d2target.THREE_DEE_OFFSET, targetShape.Width+d2target.THREE_DEE_OFFSET, targetShape.Height+d2target.THREE_DEE_OFFSET,
 		),
 		fmt.Sprintf(`<rect x="%d" y="%d" width="%d" height="%d" fill="white"></rect>`,
-			targetShape.Pos.X, targetShape.Pos.Y-threeDeeOffset, targetShape.Width+threeDeeOffset, targetShape.Height+threeDeeOffset,
+			targetShape.Pos.X, targetShape.Pos.Y-d2target.THREE_DEE_OFFSET, targetShape.Width+d2target.THREE_DEE_OFFSET, targetShape.Height+d2target.THREE_DEE_OFFSET,
 		),
 		fmt.Sprintf(`<path d="%s" style="%s;stroke:#000;fill:none;opacity:1;"/></mask></defs>`,
 			strings.Join(borderSegments, ""), borderStyle),
@@ -626,9 +625,9 @@ func render3dRect(targetShape d2target.Shape) string {
 	var sidePoints []string
 	for _, v := range []d2target.Point{
 		{X: 0, Y: 0},
-		{X: threeDeeOffset, Y: -threeDeeOffset},
-		{X: targetShape.Width + threeDeeOffset, Y: -threeDeeOffset},
-		{X: targetShape.Width + threeDeeOffset, Y: targetShape.Height - threeDeeOffset},
+		{X: d2target.THREE_DEE_OFFSET, Y: -d2target.THREE_DEE_OFFSET},
+		{X: targetShape.Width + d2target.THREE_DEE_OFFSET, Y: -d2target.THREE_DEE_OFFSET},
+		{X: targetShape.Width + d2target.THREE_DEE_OFFSET, Y: targetShape.Height - d2target.THREE_DEE_OFFSET},
 		{X: targetShape.Width, Y: targetShape.Height},
 		{X: targetShape.Width, Y: 0},
 	} {

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -21,6 +21,8 @@ import (
 const (
 	DEFAULT_ICON_SIZE = 32
 	MAX_ICON_SIZE     = 64
+
+	THREE_DEE_OFFSET = 15
 )
 
 type Diagram struct {
@@ -87,6 +89,11 @@ func (diagram Diagram) BoundingBox() (topLeft, bottomRight Point) {
 			y1 = go2.Min(y1, int(labelTL.Y))
 			x2 = go2.Max(x2, int(labelTL.X)+targetShape.LabelWidth)
 			y2 = go2.Max(y2, int(labelTL.Y)+targetShape.LabelHeight)
+		}
+
+		if targetShape.ThreeDee {
+			y1 = go2.Min(y1, targetShape.Pos.Y-THREE_DEE_OFFSET-targetShape.StrokeWidth)
+			x2 = go2.Max(x2, targetShape.Pos.X+THREE_DEE_OFFSET+targetShape.Width+targetShape.StrokeWidth)
 		}
 	}
 


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

No dedicated test because e2e tests don't use 0-padding. maybe they should though.... https://github.com/terrastruct/d2/issues/682

### Before

![Screen Shot 2023-01-19 at 11 47 37 AM](https://user-images.githubusercontent.com/3120367/213545985-2c9197b0-5c19-47f6-a8ef-deb550479b50.png)

### After

![Screen Shot 2023-01-19 at 11 53 19 AM](https://user-images.githubusercontent.com/3120367/213546002-951f5430-29cf-4562-9dcd-058bcad8b921.png)
