### PR TITLE
docs: remove twitter badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![daily](https://github.com/terrastruct/d2/actions/workflows/daily.yml/badge.svg)](https://github.com/terrastruct/d2/actions/workflows/daily.yml)
 [![release](https://img.shields.io/github/v/release/terrastruct/d2)](https://github.com/terrastruct/d2/releases)
 [![discord](https://img.shields.io/discord/1039184639652265985?label=discord)](https://discord.gg/NF6X8K4eDq)
-[![twitter](https://img.shields.io/twitter/follow/terrastruct?style=social)](https://twitter.com/terrastruct)
 [![license](https://img.shields.io/github/license/terrastruct/d2?color=9cf)](./LICENSE.txt)
 
 <a href="https://play.d2lang.com">


### PR DESCRIPTION
The Twitter API now blocks follower counts from appearing on the badge, which resulted in this badge displaying an error.
