### PR TITLE
testing chaos with more readable/simpler ids and labels

### DIFF
--- a/d2chaos/d2chaos.go
+++ b/d2chaos/d2chaos.go
@@ -62,7 +62,7 @@ func (gs *dslGenState) gen(maxi int) error {
 }
 
 func (gs *dslGenState) genNode(containerID string) (string, error) {
-	nodeID := gs.randStr(32, true)
+	nodeID := gs.randStr(8, true)
 	if containerID != "" {
 		nodeID = containerID + "." + nodeID
 	}
@@ -95,7 +95,7 @@ func (gs *dslGenState) node() error {
 
 	if gs.roll(25, 75) == 0 {
 		// 25% chance of adding a label.
-		gs.g, err = d2oracle.Set(gs.g, nodeID, nil, go2.Pointer(gs.randStr(256, false)))
+		gs.g, err = d2oracle.Set(gs.g, nodeID, nil, go2.Pointer(gs.randStr(8, false)))
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func (gs *dslGenState) edge() error {
 		return err
 	}
 	if gs.randBool() {
-		gs.g, err = d2oracle.Set(gs.g, key, nil, go2.Pointer(gs.randStr(128, false)))
+		gs.g, err = d2oracle.Set(gs.g, key, nil, go2.Pointer(gs.randStr(8, false)))
 		if err != nil {
 			return err
 		}
@@ -191,11 +191,7 @@ func (gs *dslGenState) randBool() bool {
 // TODO go back to using xrand.String, currently some incompatibility with
 // stuffing these strings into a script for dagre
 func randRune() rune {
-	if mathrand.Int31n(100) == 0 {
-		// Generate newline 1% of the time.
-		return '\n'
-	}
-	return mathrand.Int31n(128) + 1
+	return mathrand.Int31n(26) + 97
 }
 
 func (gs *dslGenState) findOuterSequenceDiagram(nodeID string) string {

--- a/d2chaos/d2chaos.go
+++ b/d2chaos/d2chaos.go
@@ -15,6 +15,8 @@ import (
 	"oss.terrastruct.com/d2/d2target"
 )
 
+const complexIDs = false
+
 func GenDSL(maxi int) (_ string, err error) {
 	gs := &dslGenState{
 		rand:          mathrand.New(mathrand.NewSource(time.Now().UnixNano())),
@@ -62,7 +64,11 @@ func (gs *dslGenState) gen(maxi int) error {
 }
 
 func (gs *dslGenState) genNode(containerID string) (string, error) {
-	nodeID := gs.randStr(8, true)
+	maxLen := 8
+	if complexIDs {
+		maxLen = 32
+	}
+	nodeID := gs.randStr(maxLen, true)
 	if containerID != "" {
 		nodeID = containerID + "." + nodeID
 	}
@@ -95,7 +101,11 @@ func (gs *dslGenState) node() error {
 
 	if gs.roll(25, 75) == 0 {
 		// 25% chance of adding a label.
-		gs.g, err = d2oracle.Set(gs.g, nodeID, nil, go2.Pointer(gs.randStr(8, false)))
+		maxLen := 8
+		if complexIDs {
+			maxLen = 256
+		}
+		gs.g, err = d2oracle.Set(gs.g, nodeID, nil, go2.Pointer(gs.randStr(maxLen, false)))
 		if err != nil {
 			return err
 		}
@@ -154,7 +164,11 @@ func (gs *dslGenState) edge() error {
 		return err
 	}
 	if gs.randBool() {
-		gs.g, err = d2oracle.Set(gs.g, key, nil, go2.Pointer(gs.randStr(8, false)))
+		maxLen := 8
+		if complexIDs {
+			maxLen = 128
+		}
+		gs.g, err = d2oracle.Set(gs.g, key, nil, go2.Pointer(gs.randStr(maxLen, false)))
 		if err != nil {
 			return err
 		}
@@ -191,7 +205,15 @@ func (gs *dslGenState) randBool() bool {
 // TODO go back to using xrand.String, currently some incompatibility with
 // stuffing these strings into a script for dagre
 func randRune() rune {
-	return mathrand.Int31n(26) + 97
+	if complexIDs {
+		if mathrand.Int31n(100) == 0 {
+			// Generate newline 1% of the time.
+			return '\n'
+		}
+		return mathrand.Int31n(128) + 1
+	} else {
+		return mathrand.Int31n(26) + 97
+	}
 }
 
 func (gs *dslGenState) findOuterSequenceDiagram(nodeID string) string {


### PR DESCRIPTION

## Summary

d2 chaos but with less chaos in IDs and labels so it is much easier to see what the problem is when there is a failure.

## Details
- related #752 

### before

```
    --- FAIL: TestD2Chaos/#00 (0.00s)
        d2chaos_test.go:82: failed to create "\"cP\\n\x19*U<Sx\bH#\x05gE\x06u\".\"+hxZyS\x11hZT)wv\\$\x18\x11;N!i-sI4\v^)\x1f\" -> \"cP\\n\x19*U<Sx\bH#\x05gE\x06u\".\"+hxZyS\x11hZT)wv\\$\x18\x11;N!i-sI4\v^)\x1f\".\"\"": failed to recompile:
            "cP\n*U<SH#gEu": {
              "+hxZyShZT)wv\$;N!i-sI4
                                     ^)": {
                shape: cloud
                v: {shape: circle}
                "": {
                  shape: sequence_diagram
p]      5:-Qw[(S=Te-<Di hsJ0'8Tl3tMH/4nQ[Z]W": '"YG\$pCd0jS;42
h7]ZO]  nL*\$Jrw       PZ0&c9%  f61>\n|d:G%n)\n#7|@WfUzR^Zk&SG
<z\n73Cg"' {shape: rectangle}X\n8E;A4
                }
              }
              "N]": {shape: package}
              "+hxZyShZT)wv\$;N!i-sI4
                                     ^)" -> "+hxZyShZT)wv\$;N!i-sI4
                                                                   ^)".""
            }
            "cP\n*U<SH#gEu" -- "cP\n*U<SH#gEu": Kv
            "cP\n*U<SH#gEu" <-> "cP\n*U<SH#gEu"
            
            11:37: cannot create edges between boards
FAIL
```

### after

```
 d2chaos_test.go:82: failed to create "iopouz <-> iopouz.\"\"": failed to recompile:
        iopouz: {
          shape: page
          atx: {shape: code}
          ""
        }
        nv: {shape: code}
        iopouz.atx -- iopouz
        iopouz <-> iopouz.atx: pcneaoj
        nv -- iopouz: owklh
        nv -> iopouz
        iopouz <-> iopouz.""
        
        11:11: cannot create edges between boards
```
