### PR TITLE
fix e2ereport to ensure test paths are relative to report

### DIFF
--- a/e2etests/report/main.go
+++ b/e2etests/report/main.go
@@ -100,7 +100,11 @@ func main() {
 				}
 
 				if matchTestSet && matchTestCase {
-					fullPath := filepath.Join(path, testFile.Name())
+					absPath, err := filepath.Abs(path)
+					if err != nil {
+						stdlog.Fatal(err)
+					}
+					fullPath := filepath.Join(absPath, testFile.Name())
 					hasGot := false
 					gotPath := strings.Replace(fullPath, "exp.svg", "got.svg", 1)
 					if _, err := os.Stat(gotPath); err == nil {
@@ -143,10 +147,6 @@ func main() {
 			panic(err)
 		}
 
-		tmplData := TemplateData{
-			Tests: tests,
-		}
-
 		path := os.Getenv("REPORT_OUTPUT")
 		if path == "" {
 			path = filepath.Join(testDir, "./out/e2e_report.html")
@@ -159,7 +159,34 @@ func main() {
 		if err != nil {
 			panic(fmt.Errorf("error creating file `%s`. %v", path, err))
 		}
-		if err := tmpl.Execute(f, tmplData); err != nil {
+		absReportDir, err := filepath.Abs(filepath.Dir(path))
+		if err != nil {
+			stdlog.Fatal(err)
+		}
+
+		// get the test path relative to the report
+		reportRelPath := func(testPath string) string {
+			absTestPath, err := filepath.Abs(testPath)
+			if err != nil {
+				stdlog.Fatal(err)
+			}
+			relTestPath, err := filepath.Rel(absReportDir, absTestPath)
+			if err != nil {
+				stdlog.Fatal(err)
+			}
+			return relTestPath
+		}
+
+		// update test paths to be relative to report file
+		for i := range tests {
+			testItem := &tests[i]
+			testItem.GotSVG = reportRelPath(testItem.GotSVG)
+			if testItem.ExpSVG != nil {
+				*testItem.ExpSVG = reportRelPath(*testItem.ExpSVG)
+			}
+		}
+
+		if err := tmpl.Execute(f, TemplateData{Tests: tests}); err != nil {
 			panic(err)
 		}
 	}

--- a/e2etests/report/main.go
+++ b/e2etests/report/main.go
@@ -166,11 +166,7 @@ func main() {
 
 		// get the test path relative to the report
 		reportRelPath := func(testPath string) string {
-			absTestPath, err := filepath.Abs(testPath)
-			if err != nil {
-				stdlog.Fatal(err)
-			}
-			relTestPath, err := filepath.Rel(absReportDir, absTestPath)
+			relTestPath, err := filepath.Rel(absReportDir, testPath)
 			if err != nil {
 				stdlog.Fatal(err)
 			}

--- a/e2etests/report/template.html
+++ b/e2etests/report/template.html
@@ -10,16 +10,16 @@
     <div class="cases">
       {{range .Tests}}
       <div class="case" id="{{.Name}}">
-        <h1><a href="../../{{.GotSVG}}">{{.Name}}</a></h1>
+        <h1><a href="{{.GotSVG}}">{{.Name}}</a></h1>
         {{ if .ExpSVG }}
         <h2 class="case-exp">Expected</h2>
         {{ end }}
         <h2 class="case-got">Got</h2>
         <div class="case-img-wrapper">
           {{ if .ExpSVG }}
-          <img src="../../{{.ExpSVG}}" width="100%" />
+          <img src="{{.ExpSVG}}" width="100%" />
           {{ end }}
-          <img src="../../{{.GotSVG}}" width="100%" />
+          <img src="{{.GotSVG}}" width="100%" />
         </div>
       </div>
       {{end}}
@@ -41,7 +41,7 @@
       .case img {
         width: 600px;
       }
-      .case-got {
+      .case-exp + .case-got {
         position: absolute;
         left: 600px;
       }


### PR DESCRIPTION

## Summary

If the `REPORT_OUTPUT` env var is used, the links to svgs in the e2ereport would not be correct.
This fixes the broken report links by ensuring they are set to be relative to the report even if it is not in the default file location.

## Details
- store abs paths in TestItem
- get abs path of report directory
- compute relative path of test svg (relative to report) and use that in the report
- fixed `Got` label position when not running `-delta` flag

### before: paths in report would be incorrect with a different `REPORT_OUTPUT`

![Screen Shot 2023-02-10 at 1 42 06 PM](https://user-images.githubusercontent.com/85081687/218204578-d33d46ae-ac5f-49b0-ae2e-7db5edbdb567.png)

### working delta

![Screen Shot 2023-02-10 at 1 41 19 PM](https://user-images.githubusercontent.com/85081687/218205079-79478dfa-d26a-4ce9-9896-5150a8858ba5.png)

### before Got label position non-delta

![Screen Shot 2023-02-10 at 1 41 12 PM](https://user-images.githubusercontent.com/85081687/218204990-14bcf639-07ff-4590-8111-ca9a580cacb5.png)

### after Got label position non-delta

![Screen Shot 2023-02-10 at 1 41 26 PM](https://user-images.githubusercontent.com/85081687/218205162-0471b4ce-5f09-49bd-8149-d0ece1f8291f.png)

