### PR TITLE
watch: Fix duplicate logs and remove timestamps

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -1,8 +1,11 @@
 #### Features 🚀
 
 - Many non-Latin languages (e.g. Chinese, Japanese, Korean) are usable now that multi-byte characters are measured correctly. [#817](https://github.com/terrastruct/d2/pull/817)
+- Fix duplicate success logs in watch mode. [830](https://github.com/terrastruct/d2/pull/830)
 
 #### Improvements 🧹
+
+- Cleaner watch mode logs without timestamps. [830](https://github.com/terrastruct/d2/pull/830)
 
 #### Bugfixes ⛑️
 

--- a/watch.go
+++ b/watch.go
@@ -367,8 +367,6 @@ func (w *watcher) compileLoop(ctx context.Context) error {
 			}
 			errs = err.Error()
 			w.ms.Log.Error.Print(errs)
-		} else {
-			w.ms.Log.Success.Printf("successfully %scompiled %v to %v", recompiledPrefix, w.inputPath, w.outputPath)
 		}
 		w.broadcast(&compileResult{
 			SVG: string(svg),


### PR DESCRIPTION
Instead we log the duration each layer's full compilation took.

<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
