### PR TITLE
d2plugin: Have each plugin return the correct Type

### DIFF
--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -119,6 +119,9 @@ func (p *execPlugin) Info(ctx context.Context) (_ *PluginInfo, err error) {
 		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
+	info.Type = "binary"
+	info.Path = p.path
+
 	p.info = &info
 	return &info, nil
 }

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -71,7 +71,8 @@ type PluginInfo struct {
 	ShortHelp string `json:"shortHelp"`
 	LongHelp  string `json:"longHelp"`
 
-	// These two are set by ListPlugins and not the plugin itself.
+	// Set to bundled when returning from the plugin.
+	// execPlugin will set to binary when used.
 	// bundled | binary
 	Type string `json:"type"`
 	// If Type == binary then this contains the absolute path to the binary.
@@ -121,12 +122,6 @@ func ListPluginInfos(ctx context.Context, ps []Plugin) ([]*PluginInfo, error) {
 		info, err := p.Info(ctx)
 		if err != nil {
 			return nil, err
-		}
-		if ep, ok := p.(*execPlugin); ok {
-			info.Type = "binary"
-			info.Path = ep.path
-		} else {
-			info.Type = "bundled"
 		}
 		infoSlice = append(infoSlice, info)
 	}

--- a/d2plugin/plugin_dagre.go
+++ b/d2plugin/plugin_dagre.go
@@ -66,6 +66,7 @@ func (p dagrePlugin) Info(ctx context.Context) (*PluginInfo, error) {
 
 	return &PluginInfo{
 		Name:      "dagre",
+		Type:      "bundled",
 		ShortHelp: "The directed graph layout library Dagre",
 		LongHelp: fmt.Sprintf(`dagre is a directed graph layout library for JavaScript.
 See https://d2lang.com/tour/dagre for more.

--- a/d2plugin/plugin_elk.go
+++ b/d2plugin/plugin_elk.go
@@ -86,6 +86,7 @@ func (p elkPlugin) Info(ctx context.Context) (*PluginInfo, error) {
 	}
 	return &PluginInfo{
 		Name:      "elk",
+		Type:      "bundled",
 		ShortHelp: "Eclipse Layout Kernel (ELK) with the Layered algorithm.",
 		LongHelp: fmt.Sprintf(`ELK is a layout engine offered by Eclipse.
 Originally written in Java, it has been ported to Javascript and cross-compiled into D2.


### PR DESCRIPTION
A plugin from FindPlugin will now return the correct Type and Path when
calling info on it. Before, they would only be set on ListPluginInfos
which makes no sense.
