### PR TITLE
serde: fiz deserialize

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -13,3 +13,4 @@
 - Fixes rare compiler bug when using underscores in edges to create objects across containers. [#824](https://github.com/terrastruct/d2/pull/824)
 - Fixes rare possibility of rendered connections being hidden or cut off. [#828](https://github.com/terrastruct/d2/pull/828)
 - Creating nested children within `sql_table` and `class` shapes are now prevented (caused confusion when accidentally done). [#834](https://github.com/terrastruct/d2/pull/834)
+- Fixes graph deserialization. [#837](https://github.com/terrastruct/d2/pull/837)

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -13,4 +13,4 @@
 - Fixes rare compiler bug when using underscores in edges to create objects across containers. [#824](https://github.com/terrastruct/d2/pull/824)
 - Fixes rare possibility of rendered connections being hidden or cut off. [#828](https://github.com/terrastruct/d2/pull/828)
 - Creating nested children within `sql_table` and `class` shapes are now prevented (caused confusion when accidentally done). [#834](https://github.com/terrastruct/d2/pull/834)
-- Fixes graph deserialization. [#837](https://github.com/terrastruct/d2/pull/837)
+- Fixes graph deserialization bug. [#837](https://github.com/terrastruct/d2/pull/837)

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -2,7 +2,6 @@ package d2graph
 
 import (
 	"encoding/json"
-	"strings"
 
 	"oss.terrastruct.com/util-go/go2"
 )
@@ -49,7 +48,7 @@ func DeserializeGraph(bytes []byte, g *Graph) error {
 			for _, id := range so["ChildrenArray"].([]interface{}) {
 				o := idToObj[id.(string)]
 				childrenArray = append(childrenArray, o)
-				children[strings.ToLower(id.(string))] = o
+				children[o.IDVal] = o
 
 				o.Parent = idToObj[so["AbsID"].(string)]
 			}

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -2,6 +2,7 @@ package d2graph
 
 import (
 	"encoding/json"
+	"strings"
 
 	"oss.terrastruct.com/util-go/go2"
 )
@@ -48,7 +49,7 @@ func DeserializeGraph(bytes []byte, g *Graph) error {
 			for _, id := range so["ChildrenArray"].([]interface{}) {
 				o := idToObj[id.(string)]
 				childrenArray = append(childrenArray, o)
-				children[o.IDVal] = o
+				children[strings.ToLower(o.IDVal)] = o
 
 				o.Parent = idToObj[so["AbsID"].(string)]
 			}

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -49,7 +49,7 @@ func DeserializeGraph(bytes []byte, g *Graph) error {
 			for _, id := range so["ChildrenArray"].([]interface{}) {
 				o := idToObj[id.(string)]
 				childrenArray = append(childrenArray, o)
-				children[strings.ToLower(o.IDVal)] = o
+				children[strings.ToLower(o.ID)] = o
 
 				o.Parent = idToObj[so["AbsID"].(string)]
 			}

--- a/d2graph/serde_test.go
+++ b/d2graph/serde_test.go
@@ -17,25 +17,19 @@ func TestSerialization(t *testing.T) {
 	assert.Nil(t, err)
 
 	asserts := func(g *d2graph.Graph) {
+		a := g.Root.ChildrenArray[0]
+		a_a := a.ChildrenArray[0]
+
 		assert.Equal(t, 4, len(g.Objects))
 		assert.Equal(t, 1, len(g.Root.ChildrenArray))
-		assert.Equal(t, 1, len(g.Root.ChildrenArray[0].ChildrenArray))
-		assert.Equal(t, 2, len(g.Root.ChildrenArray[0].ChildrenArray[0].ChildrenArray))
-		assert.Equal(t,
-			g.Root.ChildrenArray[0],
-			g.Root.ChildrenArray[0].ChildrenArray[0].Parent,
-		)
+		assert.Equal(t, 1, len(a.ChildrenArray))
+		assert.Equal(t, 2, len(a_a.ChildrenArray))
+		assert.Equal(t, a, a_a.Parent)
+		assert.Equal(t, g.Root, a.Parent)
 
-		assert.Equal(t,
-			g.Root,
-			g.Root.ChildrenArray[0].Parent,
-		)
-
-		a := g.Root.ChildrenArray[0]
-		aa := a.ChildrenArray[0]
 		assert.Contains(t, a.Children, "a")
-		assert.Contains(t, aa.Children, "b")
-		assert.Contains(t, aa.Children, "c")
+		assert.Contains(t, a_a.Children, "b")
+		assert.Contains(t, a_a.Children, "c")
 
 		assert.Equal(t, 1, len(g.Edges))
 		assert.Equal(t, "b", g.Edges[0].Src.ID)

--- a/d2graph/serde_test.go
+++ b/d2graph/serde_test.go
@@ -31,6 +31,12 @@ func TestSerialization(t *testing.T) {
 			g.Root.ChildrenArray[0].Parent,
 		)
 
+		a := g.Root.ChildrenArray[0]
+		aa := a.ChildrenArray[0]
+		assert.Contains(t, a.Children, "a")
+		assert.Contains(t, aa.Children, "b")
+		assert.Contains(t, aa.Children, "c")
+
 		assert.Equal(t, 1, len(g.Edges))
 		assert.Equal(t, "b", g.Edges[0].Src.ID)
 		assert.Equal(t, "c", g.Edges[0].Dst.ID)


### PR DESCRIPTION
when rendering the following diagram with `TALA`, it errored when adding `no collision.near: game loop.collision detected`

```
direction: down
first input -> start game -> game loop

game loop: {
  direction: down
  input -> increase bird top velocity

  move bird -> move pipes -> render

  render -> no collision -> wait 16 milliseconds -> move bird
  render -> collision detected -> game over
  no collision.near: game loop.collision detected
}
```

The reason was that when deserializing the graph, `game loop.Children` had the full path `game loop.collision detection` instead of just `collision detection`. Then, TALA failed to find the `near` object and resulted in a `panic`.
