### PR TITLE
validate near key better

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -6,6 +6,7 @@
 #### Improvements 🧹
 
 - Cleaner watch mode logs without timestamps. [830](https://github.com/terrastruct/d2/pull/830)
+- `near` key set to direct parent or ancestor throws an appropriate error message. [#851](https://github.com/terrastruct/d2/pull/851)
 
 #### Bugfixes ⛑️
 

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -1400,6 +1400,29 @@ x -> y: {
 `,
 		},
 		{
+			name: "near-invalid",
+
+			text: `mongodb: MongoDB {
+  perspective: perspective (View) {
+    password
+  }
+
+  explanation: |md
+    perspective.model.js
+  | {
+    near: mongodb
+  }
+}
+
+a: {
+  near: a.b
+  b
+}
+`,
+			expErr: `d2/testdata/d2compiler/TestCompile/near-invalid.d2:9:11: near keys cannot be set to an ancestor
+d2/testdata/d2compiler/TestCompile/near-invalid.d2:14:9: near keys cannot be set to an descendant`,
+		},
+		{
 			name: "near_bad_constant",
 
 			text: `x.near: txop-center

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -2220,7 +2220,7 @@ a.b.c: {
 `,
 		},
 		{
-			name: "near",
+			name: "invalid-near",
 
 			text: `x: {
   near: y
@@ -2232,6 +2232,33 @@ y
 
 			exp: `x: {
   near: x.y
+  y
+}
+`,
+			expErr: `failed to move: "y" to "x.y": failed to recompile:
+x: {
+  near: x.y
+  y
+}
+
+d2/testdata/d2oracle/TestMove/invalid-near.d2:2:9: near keys cannot be set to an descendant`,
+		},
+		{
+			name: "near",
+
+			text: `x: {
+  near: y
+}
+a
+y
+`,
+			key:    `y`,
+			newKey: `a.y`,
+
+			exp: `x: {
+  near: a.y
+}
+a: {
   y
 }
 `,

--- a/testdata/d2compiler/TestCompile/near-invalid.exp.json
+++ b/testdata/d2compiler/TestCompile/near-invalid.exp.json
@@ -1,0 +1,16 @@
+{
+  "graph": null,
+  "err": {
+    "ioerr": null,
+    "errs": [
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/near-invalid.d2,8:10:133-8:17:140",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/near-invalid.d2:9:11: near keys cannot be set to an ancestor"
+      },
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/near-invalid.d2,13:8:161-13:11:164",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/near-invalid.d2:14:9: near keys cannot be set to an descendant"
+      }
+    ]
+  }
+}

--- a/testdata/d2oracle/TestMove/invalid-near.exp.json
+++ b/testdata/d2oracle/TestMove/invalid-near.exp.json
@@ -1,0 +1,4 @@
+{
+  "graph": null,
+  "err": "failed to move: \"y\" to \"x.y\": failed to recompile:\nx: {\n  near: x.y\n  y\n}\n\nd2/testdata/d2oracle/TestMove/invalid-near.d2:2:9: near keys cannot be set to an descendant"
+}

--- a/testdata/d2oracle/TestMove/near.exp.json
+++ b/testdata/d2oracle/TestMove/near.exp.json
@@ -2,11 +2,11 @@
   "graph": {
     "name": "",
     "ast": {
-      "range": "d2/testdata/d2oracle/TestMove/near.d2,0:0:0-4:0:23",
+      "range": "d2/testdata/d2oracle/TestMove/near.d2,0:0:0-6:0:30",
       "nodes": [
         {
           "map_key": {
-            "range": "d2/testdata/d2oracle/TestMove/near.d2,0:0:0-3:1:22",
+            "range": "d2/testdata/d2oracle/TestMove/near.d2,0:0:0-2:1:18",
             "key": {
               "range": "d2/testdata/d2oracle/TestMove/near.d2,0:0:0-0:1:1",
               "path": [
@@ -26,7 +26,7 @@
             "primary": {},
             "value": {
               "map": {
-                "range": "d2/testdata/d2oracle/TestMove/near.d2,0:3:3-3:0:21",
+                "range": "d2/testdata/d2oracle/TestMove/near.d2,0:3:3-2:0:17",
                 "nodes": [
                   {
                     "map_key": {
@@ -53,23 +53,52 @@
                           "range": "d2/testdata/d2oracle/TestMove/near.d2,1:8:13-1:11:16",
                           "value": [
                             {
-                              "string": "x.y",
-                              "raw_string": "x.y"
+                              "string": "a.y",
+                              "raw_string": "a.y"
                             }
                           ]
                         }
                       }
                     }
-                  },
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestMove/near.d2,3:0:19-5:1:29",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/near.d2,3:0:19-3:1:20",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/near.d2,3:0:19-3:1:20",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestMove/near.d2,3:3:22-5:0:28",
+                "nodes": [
                   {
                     "map_key": {
-                      "range": "d2/testdata/d2oracle/TestMove/near.d2,2:2:19-2:3:20",
+                      "range": "d2/testdata/d2oracle/TestMove/near.d2,4:2:26-4:3:27",
                       "key": {
-                        "range": "d2/testdata/d2oracle/TestMove/near.d2,2:2:19-2:3:20",
+                        "range": "d2/testdata/d2oracle/TestMove/near.d2,4:2:26-4:3:27",
                         "path": [
                           {
                             "unquoted_string": {
-                              "range": "d2/testdata/d2oracle/TestMove/near.d2,2:2:19-2:3:20",
+                              "range": "d2/testdata/d2oracle/TestMove/near.d2,4:2:26-4:3:27",
                               "value": [
                                 {
                                   "string": "y",
@@ -160,8 +189,8 @@
                   "range": ",0:0:0-0:1:1",
                   "value": [
                     {
-                      "string": "x",
-                      "raw_string": "x"
+                      "string": "a",
+                      "raw_string": "a"
                     }
                   ]
                 }
@@ -192,6 +221,53 @@
         "zIndex": 0
       },
       {
+        "id": "a",
+        "id_val": "a",
+        "label_dimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/near.d2,3:0:19-3:1:20",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/near.d2,3:0:19-3:1:20",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "a"
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
         "id": "y",
         "id_val": "y",
         "label_dimensions": {
@@ -201,11 +277,11 @@
         "references": [
           {
             "key": {
-              "range": "d2/testdata/d2oracle/TestMove/near.d2,2:2:19-2:3:20",
+              "range": "d2/testdata/d2oracle/TestMove/near.d2,4:2:26-4:3:27",
               "path": [
                 {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2oracle/TestMove/near.d2,2:2:19-2:3:20",
+                    "range": "d2/testdata/d2oracle/TestMove/near.d2,4:2:26-4:3:27",
                     "value": [
                       {
                         "string": "y",


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

near key cannot be set to direct ancestor or descendant. it makes no sense.

Thanks to https://discord.com/channels/976899413542830181/1019365046486306957/1076895091379154977