### PR TITLE
Add playwright deps to arm64 docker image

### DIFF
--- a/ci/release/build.sh
+++ b/ci/release/build.sh
@@ -263,12 +263,12 @@ build_docker() {
     return 0
   fi
 
-  sh_c lockfile_ssh "$CI_D2_LINUX_AMD64" .d2-build-lock
-  sh_c gitsync "$CI_D2_LINUX_AMD64" src/d2
+  sh_c lockfile_ssh "$CI_D2_LINUX_ARM64" .d2-build-lock
+  sh_c gitsync "$CI_D2_LINUX_ARM64" src/d2
   sh_c rsync --archive --human-readable \
     "$BUILD_DIR/d2-$VERSION"-linux-*.tar.gz \
-    "$CI_D2_LINUX_AMD64:src/d2/$BUILD_DIR/"
-  sh_c ssh "$CI_D2_LINUX_AMD64" \
+    "$CI_D2_LINUX_ARM64:src/d2/$BUILD_DIR/"
+  sh_c ssh "$CI_D2_LINUX_ARM64" \
     "D2_DOCKER_IMAGE=${D2_DOCKER_IMAGE-}" \
     "RELEASE=${RELEASE-}" \
     ./src/d2/ci/release/docker/build.sh \

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -3,12 +3,14 @@
 - PDF exports are now supported. [#120](https://github.com/terrastruct/d2/issues/120)
 - Diagram background can be styled. [#910](https://github.com/terrastruct/d2/issues/910)
 - 3D Hexagons are now supported. [#869](https://github.com/terrastruct/d2/issues/869)
+- The arm64 docker container now supports rendering diagrams to pngs. [#917](https://github.com/terrastruct/d2/pull/917)
 
 #### Improvements 🧹
 
 - `near` key set to sequence diagram children get an appropriate error message. [#899](https://github.com/terrastruct/d2/issues/899)
 - `class` and `sql_table` shape respect `font-color` styling as header font color. [#899](https://github.com/terrastruct/d2/issues/899)
 - SVG fits to screen by default in both watch mode and as a standalone SVG (this time with just CSS, no JS). [#725](https://github.com/terrastruct/d2/issues/725)
+- Only chromium is installed when rendering png diagrams instead of also installing webkit and firefox. [#835](https://github.com/terrastruct/d2/issues/835)
 
 #### Bugfixes ⛑️
 

--- a/ci/release/docker/Dockerfile
+++ b/ci/release/docker/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && apt-get install -y ca-certificates curl dumb-init sudo
 
 RUN curl -fsSL https://deb.nodesource.com/setup_19.x | bash -s - && \
   apt-get install -y nodejs
-# https://github.com/microsoft/playwright/issues/18319
-# Hopefully soon.
-RUN if [ "$TARGETARCH" = amd64 ]; then npx playwright install-deps; fi
+# @next until 1.31 for arm64 debian support.
+# See https://github.com/microsoft/playwright/issues/18319
+RUN npx playwright@next install-deps chromium
 
 RUN adduser --gecos '' --disabled-password debian \
   && echo "debian ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
@@ -28,7 +28,7 @@ RUN mkdir -p /usr/local/lib/d2 \
       && rm -Rf /tmp/d2-*-linux-"$TARGETARCH".tar.gz
 
 USER debian:debian
-RUN if [ "$TARGETARCH" = amd64 ]; then d2 init-playwright; fi
+RUN d2 init-playwright
 
 WORKDIR /home/debian/src
 EXPOSE 8080

--- a/ci/release/docker/Dockerfile
+++ b/ci/release/docker/Dockerfile
@@ -7,9 +7,8 @@ RUN apt-get update && apt-get install -y ca-certificates curl dumb-init sudo
 
 RUN curl -fsSL https://deb.nodesource.com/setup_19.x | bash -s - && \
   apt-get install -y nodejs
-# @next until 1.31 for arm64 debian support.
 # See https://github.com/microsoft/playwright/issues/18319
-RUN npx playwright@next install-deps chromium
+RUN npx playwright@1.31.1 install-deps chromium
 
 RUN adduser --gecos '' --disabled-password debian \
   && echo "debian ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -56,7 +56,10 @@ func startPlaywright(pw *playwright.Playwright) (Playwright, error) {
 }
 
 func InitPlaywright() (Playwright, error) {
-	err := playwright.Install(&playwright.RunOptions{Verbose: false})
+	err := playwright.Install(&playwright.RunOptions{
+		Verbose:  false,
+		Browsers: []string{"chromium"},
+	})
 	if err != nil {
 		return Playwright{}, fmt.Errorf("failed to install Playwright: %w", err)
 	}


### PR DESCRIPTION
- docker: Install playwright dependencies on arm64
- docker: Build images cross platform natively

<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
