### PR TITLE
Fix png export

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -19,3 +19,4 @@
 - Fixed img bundling on image shapes. [#889](https://github.com/terrastruct/d2/issues/889)
 - `class` shape as sequence diagram actors had wrong colors. [#899](https://github.com/terrastruct/d2/issues/899)
 - Fix regression in last release where some hex codes were not working. [#922](https://github.com/terrastruct/d2/pull/922)
+- Fixes low resolution pngs. [#931](https://github.com/terrastruct/d2/pull/931)

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -375,11 +375,13 @@ func render(ctx context.Context, ms *xmain.State, compileDur time.Duration, plug
 }
 
 func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, sketch bool, pad int64, themeID int64, darkThemeID *int64, outputPath string, bundle, forceAppendix bool, page playwright.Page, ruler *textmeasure.Ruler, diagram *d2target.Diagram) ([]byte, error) {
+	toPNG := filepath.Ext(outputPath) == ".png"
 	svg, err := d2svg.Render(diagram, &d2svg.RenderOpts{
-		Pad:         int(pad),
-		Sketch:      sketch,
-		ThemeID:     themeID,
-		DarkThemeID: darkThemeID,
+		Pad:           int(pad),
+		Sketch:        sketch,
+		ThemeID:       themeID,
+		DarkThemeID:   darkThemeID,
+		SetDimensions: toPNG,
 	})
 	if err != nil {
 		return nil, err
@@ -396,12 +398,12 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, sketc
 		svg, bundleErr2 = imgbundler.BundleRemote(ctx, ms, svg)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 	}
-	if forceAppendix && filepath.Ext(outputPath) != ".png" {
+	if forceAppendix && !toPNG {
 		svg = appendix.Append(diagram, ruler, svg)
 	}
 
 	out := svg
-	if filepath.Ext(outputPath) == ".png" {
+	if toPNG {
 		svg := appendix.Append(diagram, ruler, svg)
 
 		if !bundle {

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -63,6 +63,8 @@ type RenderOpts struct {
 	Sketch      bool
 	ThemeID     int64
 	DarkThemeID *int64
+	// disables the fit to screen behavior and ensures the exported svg has the exact dimensions
+	SetDimensions bool
 }
 
 func dimensions(diagram *d2target.Diagram, pad int) (left, top, width, height int) {
@@ -1602,6 +1604,7 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 	pad := DEFAULT_PADDING
 	themeID := DEFAULT_THEME
 	darkThemeID := DEFAULT_DARK_THEME
+	setDimensions := false
 	if opts != nil {
 		pad = opts.Pad
 		if opts.Sketch {
@@ -1613,6 +1616,7 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 		}
 		themeID = opts.ThemeID
 		darkThemeID = opts.DarkThemeID
+		setDimensions = opts.SetDimensions
 	}
 
 	buf := &bytes.Buffer{}
@@ -1757,9 +1761,15 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 		h += int(math.Ceil(float64(diagram.Root.StrokeWidth)/2.) * 2.)
 	}
 
-	fitToScreenWrapper := fmt.Sprintf(`<svg %s preserveAspectRatio="xMidYMid meet" viewBox="0 0 %d %d">`,
+	var dimensions string
+	if setDimensions {
+		dimensions = fmt.Sprintf(` width="%d" height="%d"`, w, h)
+	}
+
+	fitToScreenWrapper := fmt.Sprintf(`<svg %s preserveAspectRatio="xMidYMid meet" viewBox="0 0 %d %d"%s>`,
 		`xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"`,
 		w, h,
+		dimensions,
 	)
 
 	// TODO minify


### PR DESCRIPTION
## Summary

Disabling fit to screen behavior with png export so it is rendered at the correct size. Related #721.

## Details
- set dimensions on wrapper svg to disable fit screen behavior
- disable fit screen when exporting to PNG

### before

![Screen Shot 2023-02-27 at 7 08 38 PM](https://user-images.githubusercontent.com/85081687/221743550-d4508acd-bf30-4188-a0dd-6a0eb3c5ad96.png)

### after

![Screen Shot 2023-02-27 at 7 08 14 PM](https://user-images.githubusercontent.com/85081687/221743585-f44eaddb-b7ab-4801-bda2-a6621789ff1e.png)
