### PR TITLE
render: update background rect width and height for appendix

### DIFF
--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -93,9 +93,8 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	newViewbox := fmt.Sprintf(`viewBox="%s %s %s %s"`, viewboxSlice[0], viewboxSlice[1], strconv.Itoa(viewboxWidth), strconv.Itoa(viewboxHeight))
 
 	// check if outer svg has dimensions set
-	svgMatches := svgRegex.FindAllStringSubmatch(svg, 2)
 	dimensionsToUpdate := 2
-	if widthRegex.FindString(svgMatches[0][0]) != "" {
+	if widthRegex.FindString(svgRegex.FindString(svg)) != "" {
 		dimensionsToUpdate++
 	}
 

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -91,14 +91,15 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	newOuterViewbox := fmt.Sprintf(`viewBox="0 0 %d %d"`, viewboxWidth, viewboxHeight)
 	newViewbox := fmt.Sprintf(`viewBox="%s %s %s %s"`, viewboxSlice[0], viewboxSlice[1], strconv.Itoa(viewboxWidth), strconv.Itoa(viewboxHeight))
 
-	widthMatches := widthRegex.FindAllStringSubmatch(svg, 2)
-	heightMatches := heightRegex.FindAllStringSubmatch(svg, 2)
+	// update 1st 3 matches of width and height 1st is outer svg, 2nd inner svg, 3rd is background color rect
+	widthMatches := widthRegex.FindAllStringSubmatch(svg, 3)
+	heightMatches := heightRegex.FindAllStringSubmatch(svg, 3)
 	newWidth := fmt.Sprintf(`width="%s"`, strconv.Itoa(viewboxWidth))
 	newHeight := fmt.Sprintf(`height="%s"`, strconv.Itoa(viewboxHeight))
 
 	svg = strings.Replace(svg, viewboxMatches[0][0], newOuterViewbox, 1)
 	svg = strings.Replace(svg, viewboxMatch[0], newViewbox, 1)
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		svg = strings.Replace(svg, widthMatches[i][0], newWidth, 1)
 		svg = strings.Replace(svg, heightMatches[i][0], newHeight, 1)
 	}

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -92,9 +92,10 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	newOuterViewbox := fmt.Sprintf(`viewBox="0 0 %d %d"`, viewboxWidth, viewboxHeight)
 	newViewbox := fmt.Sprintf(`viewBox="%s %s %s %s"`, viewboxSlice[0], viewboxSlice[1], strconv.Itoa(viewboxWidth), strconv.Itoa(viewboxHeight))
 
-	// check if outer svg has dimensions set
 	dimensionsToUpdate := 2
-	if widthRegex.FindString(svgRegex.FindString(svg)) != "" {
+	outerSVG := svgRegex.FindString(svg)
+	// if outer svg has dimensions set we also need to update it
+	if widthRegex.FindString(outerSVG) != "" {
 		dimensionsToUpdate++
 	}
 

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -52,6 +52,7 @@ const (
 var viewboxRegex = regexp.MustCompile(`viewBox=\"([0-9\- ]+)\"`)
 var widthRegex = regexp.MustCompile(`width=\"([.0-9]+)\"`)
 var heightRegex = regexp.MustCompile(`height=\"([.0-9]+)\"`)
+var svgRegex = regexp.MustCompile(`<svg(.*?)>`)
 
 func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []byte {
 	svg := string(in)
@@ -91,15 +92,22 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	newOuterViewbox := fmt.Sprintf(`viewBox="0 0 %d %d"`, viewboxWidth, viewboxHeight)
 	newViewbox := fmt.Sprintf(`viewBox="%s %s %s %s"`, viewboxSlice[0], viewboxSlice[1], strconv.Itoa(viewboxWidth), strconv.Itoa(viewboxHeight))
 
-	// update 1st 3 matches of width and height 1st is outer svg, 2nd inner svg, 3rd is background color rect
-	widthMatches := widthRegex.FindAllStringSubmatch(svg, 3)
-	heightMatches := heightRegex.FindAllStringSubmatch(svg, 3)
+	// check if outer svg has dimensions set
+	svgMatches := svgRegex.FindAllStringSubmatch(svg, 2)
+	dimensionsToUpdate := 2
+	if widthRegex.FindString(svgMatches[0][0]) != "" {
+		dimensionsToUpdate++
+	}
+
+	// update 1st 3 matches of width and height 1st is outer svg (if dimensions are set), 2nd inner svg, 3rd is background color rect
+	widthMatches := widthRegex.FindAllStringSubmatch(svg, dimensionsToUpdate)
+	heightMatches := heightRegex.FindAllStringSubmatch(svg, dimensionsToUpdate)
 	newWidth := fmt.Sprintf(`width="%s"`, strconv.Itoa(viewboxWidth))
 	newHeight := fmt.Sprintf(`height="%s"`, strconv.Itoa(viewboxHeight))
 
 	svg = strings.Replace(svg, viewboxMatches[0][0], newOuterViewbox, 1)
 	svg = strings.Replace(svg, viewboxMatch[0], newViewbox, 1)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < dimensionsToUpdate; i++ {
 		svg = strings.Replace(svg, widthMatches[i][0], newWidth, 1)
 		svg = strings.Replace(svg, heightMatches[i][0], newHeight, 1)
 	}


### PR DESCRIPTION
## Summary

Fixes a regression where the background rect of the svg wouldn't be resized according to the appendix.
This could cause png renders with an appendix to not have the background set properly.

## Details
- missed this change in #725
- fixes regression of https://github.com/terrastruct/d2/pull/613#issuecomment-1407083640

### before

![Screen Shot 2023-02-28 at 1 18 34 PM](https://user-images.githubusercontent.com/85081687/221982467-b0c8727d-13d7-4363-82b1-4b2ac7f99577.png)

### after 

![Screen Shot 2023-02-28 at 1 19 24 PM](https://user-images.githubusercontent.com/85081687/221982572-0e6e1817-0181-4142-924d-c89072386a59.png)
