### PR TITLE
build: `make` bails on the wrong go version

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -eu
-
 if [ ! -e "$(dirname "$0")/ci/sub/.git" ]; then
   set -x
   git submodule update --init

--- a/make.sh
+++ b/make.sh
@@ -1,19 +1,6 @@
 #!/bin/sh
 set -eu
 
-REQUIRED_GO_MINOR=$(sed -En 's/^go[[:space:]]+([[:digit:].]+)$/\1/p' go.mod)
-ACTUAL_GO_VERSION=$(go version | sed -n 's/^go version go\([0-9]*\.[0-9]*\.[0-9]*\)\(.*\)/\1/p')
-
-# We use 'case' instead of '[' to match values against complex patterns, because POSIX
-# does not guarantee that '[' supports advanced features like globs and regex.
-if case "$ACTUAL_GO_VERSION" in "$REQUIRED_GO_MINOR".*) false ;; *) true ;; esac then
-  red="\e[0;91m"
-  reset="\e[0m"
-
-  printf "${red}PROBLEM: You need go %s to build d2, but you have %s installed.${reset}\n" "$REQUIRED_GO_MINOR" "$ACTUAL_GO_VERSION"
-  exit 1
-fi
-
 if [ ! -e "$(dirname "$0")/ci/sub/.git" ]; then
   set -x
   git submodule update --init
@@ -22,5 +9,12 @@ fi
 . "$(dirname "$0")/ci/sub/lib.sh"
 PATH="$(cd -- "$(dirname "$0")" && pwd)/ci/sub/bin:$PATH"
 cd -- "$(dirname "$0")"
+
+GO_VERSION=$(sed -En 's/^go[[:space:]]+([[:digit:].]+)$/\1/p' go.mod)
+
+if ! $(go version | grep -qF "${GO_VERSION}"); then
+  printferr "You need go %s to build d2.\n" "$GO_VERSION"
+  exit 1
+fi
 
 _make "$@"

--- a/make.sh
+++ b/make.sh
@@ -9,10 +9,8 @@ fi
 PATH="$(cd -- "$(dirname "$0")" && pwd)/ci/sub/bin:$PATH"
 cd -- "$(dirname "$0")"
 
-GO_VERSION=$(sed -En 's/^go[[:space:]]+([[:digit:].]+)$/\1/p' go.mod)
-
-if ! $(go version | grep -qF "${GO_VERSION}"); then
-  printferr "You need go %s to build d2.\n" "$GO_VERSION"
+if ! $(go version | grep -qF "1.18."); then
+  printferr "You need go 1.18 to build d2.\n"
   exit 1
 fi
 

--- a/make.sh
+++ b/make.sh
@@ -9,7 +9,7 @@ fi
 PATH="$(cd -- "$(dirname "$0")" && pwd)/ci/sub/bin:$PATH"
 cd -- "$(dirname "$0")"
 
-if ! $(go version | grep -qF "1.18."); then
+if ! go version | grep -qF '1.18'; then
   printferr "You need go 1.18 to build d2.\n"
   exit 1
 fi

--- a/make.sh
+++ b/make.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 set -eu
+
+REQUIRED_GO_MINOR=$(sed -En 's/^go[[:space:]]+([[:digit:].]+)$/\1/p' go.mod)
+ACTUAL_GO_VERSION=$(go version | sed -n 's/^go version go\([0-9]*\.[0-9]*\.[0-9]*\)\(.*\)/\1/p')
+
+# We use 'case' instead of '[' to match values against complex patterns, because POSIX
+# does not guarantee that '[' supports advanced features like globs and regex.
+if case "$ACTUAL_GO_VERSION" in "$REQUIRED_GO_MINOR".*) false ;; *) true ;; esac then
+  red="\e[0;91m"
+  reset="\e[0m"
+
+  printf "${red}PROBLEM: You need go %s to build d2, but you have %s installed.${reset}\n" "$REQUIRED_GO_MINOR" "$ACTUAL_GO_VERSION"
+  exit 1
+fi
+
 if [ ! -e "$(dirname "$0")/ci/sub/.git" ]; then
   set -x
   git submodule update --init

--- a/make.sh
+++ b/make.sh
@@ -10,7 +10,7 @@ PATH="$(cd -- "$(dirname "$0")" && pwd)/ci/sub/bin:$PATH"
 cd -- "$(dirname "$0")"
 
 if ! go version | grep -qF '1.18'; then
-  printferr "You need go 1.18 to build d2.\n"
+  echoerr "You need go 1.18 to build d2."
   exit 1
 fi
 


### PR DESCRIPTION
This code:

1. Extracts the required go minor from `go.mod`
2. Gets the current go version from `go version` and normalizes it
3. Checks whether the required go minor is a version prefix for the current go
version, and bails if it isn't.



The conditional is more complicated than it would be if this script supported bash extensions to the POSIX shell standard, but changing to `#!/bin/bash` seemed out of scope for this change.