### PR TITLE
d2oracle: fix conflicting id's to parent

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -11,3 +11,4 @@
 
 - Fixes a regression where PNG backgrounds could be cut off in the appendix. [#941](https://github.com/terrastruct/d2/pull/941)
 - Fixes zooming not working in watch mode. [#944](https://github.com/terrastruct/d2/pull/944)
+- [API] Fixes `DeleteIDDeltas` giving duplicate deltas in rare cases. [#957](https://github.com/terrastruct/d2/pull/957)

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -5141,6 +5141,10 @@ x.a -> x.b
 				t.Fatal(err)
 			}
 
+			if hasRepeatedValue(deltas) {
+				t.Fatalf("deltas set more than one value equal to another: %s", string(xjson.Marshal(deltas)))
+			}
+
 			ds, err := diff.Strings(tc.exp, string(xjson.Marshal(deltas)))
 			if err != nil {
 				t.Fatal(err)
@@ -5342,6 +5346,22 @@ x.y.z.w.e.p.l -> x.y.z.1.2.3.4
   "x.y.z.(w.e.p.l -> 1.2.3.4)[6]": "x.y.z.(w.e.p.l -> 1.2.3.4)[5]"
 }`,
 		},
+		{
+			name: "delete_generated_id_conflicts",
+
+			text: `Text 2: {
+	Text
+	Text 3
+}
+Text
+`,
+			key: "Text 2",
+
+			exp: `{
+  "Text 2.Text": "Text 2",
+  "Text 2.Text 3": "Text 3"
+}`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -5371,6 +5391,10 @@ x.y.z.w.e.p.l -> x.y.z.1.2.3.4
 				t.Fatal(err)
 			}
 
+			if hasRepeatedValue(deltas) {
+				t.Fatalf("deltas set more than one value equal to another: %s", string(xjson.Marshal(deltas)))
+			}
+
 			ds, err := diff.Strings(tc.exp, string(xjson.Marshal(deltas)))
 			if err != nil {
 				t.Fatal(err)
@@ -5380,6 +5404,17 @@ x.y.z.w.e.p.l -> x.y.z.1.2.3.4
 			}
 		})
 	}
+}
+
+func hasRepeatedValue(m map[string]string) bool {
+	seen := make(map[string]struct{}, len(m))
+	for _, v := range m {
+		if _, ok := seen[v]; ok {
+			return true
+		}
+		seen[v] = struct{}{}
+	}
+	return false
 }
 
 func TestRenameIDDeltas(t *testing.T) {
@@ -5521,6 +5556,10 @@ x.y.z.w.e.p.l -> x.y.z.1.2.3.4
 				}
 			} else if err != nil {
 				t.Fatal(err)
+			}
+
+			if hasRepeatedValue(deltas) {
+				t.Fatalf("deltas set more than one value equal to another: %s", string(xjson.Marshal(deltas)))
 			}
 
 			ds, err := diff.Strings(tc.exp, string(xjson.Marshal(deltas)))


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

<img width="844" alt="Screen Shot 2023-03-02 at 11 09 54 AM" src="https://user-images.githubusercontent.com/3120367/222527881-6821bd50-f25d-41d3-acb7-daed30172829.png">

also adds an assertion to all IDDelta tests to ensure that deltas never give back two IDs that equal each other.