### PR TITLE
fix delete container hoisting children

### DIFF
--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -4818,6 +4818,26 @@ A -> B
 `,
 		},
 		{
+			name: "conflicts_generated",
+			text: `Text 4
+Square: {
+  Text 4: {
+    Text 2
+  }
+  Text
+}
+`,
+			key: `Square`,
+
+			exp: `Text 4
+
+Text: {
+  Text 2
+}
+Text 2
+`,
+		},
+		{
 			name: "chaos_1",
 
 			text: `cm: {shape: cylinder}

--- a/testdata/d2oracle/TestDelete/conflicts_generated.exp.json
+++ b/testdata/d2oracle/TestDelete/conflicts_generated.exp.json
@@ -1,0 +1,326 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,0:0:0-6:0:34",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,0:0:0-0:6:6",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,0:0:0-0:6:6",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,0:0:0-0:6:6",
+                    "value": [
+                      {
+                        "string": "Text 4",
+                        "raw_string": "Text 4"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {}
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,2:0:8-4:1:26",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,2:0:8-2:4:12",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,2:0:8-2:4:12",
+                    "value": [
+                      {
+                        "string": "Text",
+                        "raw_string": "Text"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,2:6:14-4:0:25",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,3:2:18-3:8:24",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,3:2:18-3:8:24",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,3:2:18-3:8:24",
+                              "value": [
+                                {
+                                  "string": "Text 2",
+                                  "raw_string": "Text 2"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,5:0:27-5:6:33",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,5:0:27-5:6:33",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,5:0:27-5:6:33",
+                    "value": [
+                      {
+                        "string": "Text 2",
+                        "raw_string": "Text 2"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {}
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "label_dimensions": {
+        "width": 0,
+        "height": 0
+      },
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": {
+          "value": ""
+        }
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "Text 4",
+        "id_val": "Text 4",
+        "label_dimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,0:0:0-0:6:6",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,0:0:0-0:6:6",
+                    "value": [
+                      {
+                        "string": "Text 4",
+                        "raw_string": "Text 4"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "Text 4"
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "Text",
+        "id_val": "Text",
+        "label_dimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,2:0:8-2:4:12",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,2:0:8-2:4:12",
+                    "value": [
+                      {
+                        "string": "Text",
+                        "raw_string": "Text"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "Text"
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "Text 2",
+        "id_val": "Text 2",
+        "label_dimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,3:2:18-3:8:24",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,3:2:18-3:8:24",
+                    "value": [
+                      {
+                        "string": "Text 2",
+                        "raw_string": "Text 2"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "Text 2"
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "Text 2",
+        "id_val": "Text 2",
+        "label_dimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,5:0:27-5:6:33",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/conflicts_generated.d2,5:0:27-5:6:33",
+                    "value": [
+                      {
+                        "string": "Text 2",
+                        "raw_string": "Text 2"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "Text 2"
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": "<nil>"
+}


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

deleting a container hoists its children up, giving them unique IDs

there was a bug where these IDs overwrote each other.