### PR TITLE
add compiler error for near set to title with constant near

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -8,3 +8,5 @@
 - prevent `tooltip` to be an URL when `link` is already set. [#1091](https://github.com/terrastruct/d2/pull/1091)
 
 #### Bugfixes ⛑️
+
+- prevent an object's `near` from targeting a text near a constant. [#1100](https://github.com/terrastruct/d2/pull/1100)

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -726,6 +726,13 @@ func (c *compiler) validateNear(g *d2graph.Graph) {
 					c.errorf(obj.Attributes.NearKey, "near keys cannot be set to an object within sequence diagrams")
 					continue
 				}
+				if nearObj.Attributes.NearKey != nil {
+					_, nearObjNearIsConst := d2graph.NearConstants[d2graph.Key(nearObj.Attributes.NearKey)[0]]
+					if nearObjNearIsConst {
+						c.errorf(obj.Attributes.NearKey, "near keys cannot be set to an object with a constant near key")
+						continue
+					}
+				}
 			} else if isConst {
 				is := false
 				for _, e := range g.Edges {

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2255,6 +2255,19 @@ layers: {
 }`,
 			expErr: `d2/testdata/d2compiler/TestCompile/link-board-underscore-not-found.d2:7:9: invalid underscore usage`,
 		},
+		{
+			name: "near_near_const",
+			text: `
+title: Title {
+	near: top-center
+}
+
+obj {
+	near: title
+}
+`,
+			expErr: `d2/testdata/d2compiler/TestCompile/near_near_const.d2:7:8: near keys cannot be set to an object with a constant near key`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/testdata/d2compiler/TestCompile/near_near_const.exp.json
+++ b/testdata/d2compiler/TestCompile/near_near_const.exp.json
@@ -1,0 +1,12 @@
+{
+  "graph": null,
+  "err": {
+    "ioerr": null,
+    "errs": [
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/near_near_const.d2,6:7:50-6:12:55",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/near_near_const.d2:7:8: near keys cannot be set to an object with a constant near key"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Fixes an issue where a near could be set to a title object.

## Details
- title objects (with a constant near value) are separate from everything else so there shouldn't be a near to them
- adds compiler test for this scenario