### PR TITLE
fix watch mode parsing of self-closing div in svg

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -7,3 +7,4 @@
 #### Bugfixes ⛑️
 
 - Fix a bug in ID parsing [#322](https://github.com/terrastruct/d2/issues/322)
+- Fix a bug in watch mode parsing SVG [#1119](https://github.com/terrastruct/d2/issues/1119)

--- a/d2cli/static/watch.js
+++ b/d2cli/static/watch.js
@@ -25,14 +25,9 @@ function init(reconnectDelay) {
       console.debug("watch websocket received data");
     }
     if (msg.svg) {
-      // We could turn d2SVG into an actual SVG element and use outerHTML to fully replace it
-      // with the result from the renderer but unfortunately that overwrites the #d2-svg ID.
-      // Even if you add another line to set it afterwards. The parsing/interpretation of outerHTML must be async.
-      //
-      // There's no way around that short of parsing out the top level svg tag in the msg and
-      // setting innerHTML to only the actual svg innards. However then you also need to parse
-      // out the width, height and viewbox out of the top level SVG tag and update those manually.
-      d2SVG.innerHTML = msg.svg;
+      // we can't just set `d2SVG.innerHTML = msg.svg` need to parse this as xml not html
+      const parsedXML = new DOMParser().parseFromString(msg.svg, "text/xml");
+      d2SVG.replaceChildren(parsedXML.documentElement);
 
       const svgEl = d2SVG.querySelector("#d2-svg");
       // just use inner SVG in watch mode


### PR DESCRIPTION
## Summary

Fixes a bug where the svg structure could become corrupted in watch mode due to a self-closing div.

## Details
- fixes #1084 
- when setting innerHTML in watchmode, it would parse a self-closing div incorrectly
- Issue seems to be from self closing div tags being invalid in html.  https://stackoverflow.com/a/206409
- Note: in windows, a md label block is considered not an empty label, containing a `\r` char.  However this can also happen without CRLF endings a md block with 2 newlines :  

### example with 2 newlines:

```d2
you: {shape: person}
you -> form
form: {
  get: |md


  |
}
```

### before the svg is parsed incorrectly when setting innerHTML

self closing div ends up parsed as an open div tag

![Screen Shot 2023-03-31 at 1 31 49 PM](https://user-images.githubusercontent.com/85081687/229224084-15c50c7a-0dd2-418e-8310-b9070e08dd5c.png)

### after svg is valid xhtml and parsed correctly

![Screen Shot 2023-03-31 at 1 32 25 PM](https://user-images.githubusercontent.com/85081687/229224111-14819baa-5823-4416-a36a-7014f14c9cd4.png)
