### PR TITLE
chore: fixing typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
           cache: true

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
           cache: true

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -9,7 +9,7 @@ jobs:
   d2-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/terrastruct/projects/34
           github-token: ${{ secrets._GITHUB_TOKEN }}

--- a/ci/release/changelogs/v0.1.0.md
+++ b/ci/release/changelogs/v0.1.0.md
@@ -20,7 +20,7 @@ PRs when it's a visual change.
 
 - Sequence diagrams are now supported, experimentally. See [docs](https://d2lang.com/tour/sequence-diagrams). [#99](https://github.com/terrastruct/d2/issues/99)
 - Formatting of d2 scripts is supported on the CLI with the `fmt` subcommand. See `man d2` or `d2 --help`. [#292](https://github.com/terrastruct/d2/pull/292)
-- Latex is now supported. See [docs](https://d2lang.com/tour/text) for how to use. [#229](https://github.com/terrastruct/d2/pull/229)
+- LaTeX is now supported. See [docs](https://d2lang.com/tour/text) for how to use. [#229](https://github.com/terrastruct/d2/pull/229)
 - `direction` keyword is now supported to specify `up`, `down`, `right`, `left` layouts. See [docs](https://d2lang.com/tour/layouts) for more.
   [#251](https://github.com/terrastruct/d2/pull/251)
 - Self-referencing connections are now valid. E.g. `x -> x`. Render will vary based on layout engine. [#273](https://github.com/terrastruct/d2/pull/273)

--- a/ci/release/changelogs/v0.1.5.md
+++ b/ci/release/changelogs/v0.1.5.md
@@ -9,7 +9,7 @@
 
 #### Bugfixes ⛑️
 
-- Appendix seperator line no longer added to PNG export when appendix doesn't exist. [#582](https://github.com/terrastruct/d2/pull/582)
+- Appendix separator line no longer added to PNG export when appendix doesn't exist. [#582](https://github.com/terrastruct/d2/pull/582)
 - Watch mode only fits to screen on initial load. [#601](https://github.com/terrastruct/d2/pull/601)
 - Dimensions (`width`/`height`) were incorrectly giving compiler errors when applied on a shape with style. [#614](https://github.com/terrastruct/d2/pull/614)
 - `near` would collide with labels if they were on the diagram boundaries in the same position. [#617](https://github.com/terrastruct/d2/pull/617)

--- a/ci/release/changelogs/v0.3.0.md
+++ b/ci/release/changelogs/v0.3.0.md
@@ -31,4 +31,4 @@ D2 0.3 is here!
 
 - Prevents an object's `near` from targeting another object with `near` set to a constant [#1100](https://github.com/terrastruct/d2/pull/1100)
 - Fixes inaccurate bold edge label padding [#1108](https://github.com/terrastruct/d2/pull/1108)
-- Prevents Latex blocks from being uppercased in special themes [#1111](https://github.com/terrastruct/d2/pull/1111)
+- Prevents LaTeX blocks from being uppercased in special themes [#1111](https://github.com/terrastruct/d2/pull/1111)

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -250,7 +250,7 @@ func (c *compiler) compileLabel(attrs *d2graph.Attributes, f d2ir.Node) {
 	scalar := f.Primary().Value
 	switch scalar := scalar.(type) {
 	case *d2ast.Null:
-		// TODO: Delete instaed.
+		// TODO: Delete instead.
 		attrs.Label.Value = scalar.ScalarString()
 	case *d2ast.BlockString:
 		attrs.Language = scalar.Tag
@@ -669,7 +669,7 @@ var FullToShortLanguageAliases map[string]string
 func (c *compiler) compileClass(obj *d2graph.Object) {
 	obj.Class = &d2target.Class{}
 	for _, f := range obj.ChildrenArray {
-		visiblity := "public"
+		visibility := "public"
 		name := f.IDVal
 		// See https://www.uml-diagrams.org/visibility.html
 		if name != "" {
@@ -677,10 +677,10 @@ func (c *compiler) compileClass(obj *d2graph.Object) {
 			case '+':
 				name = name[1:]
 			case '-':
-				visiblity = "private"
+				visibility = "private"
 				name = name[1:]
 			case '#':
-				visiblity = "protected"
+				visibility = "protected"
 				name = name[1:]
 			}
 		}
@@ -693,7 +693,7 @@ func (c *compiler) compileClass(obj *d2graph.Object) {
 			obj.Class.Fields = append(obj.Class.Fields, d2target.ClassField{
 				Name:       name,
 				Type:       typ,
-				Visibility: visiblity,
+				Visibility: visibility,
 			})
 		} else {
 			// TODO: Not great, AST should easily allow specifying alternate primary field
@@ -705,7 +705,7 @@ func (c *compiler) compileClass(obj *d2graph.Object) {
 			obj.Class.Methods = append(obj.Class.Methods, d2target.ClassMethod{
 				Name:       name,
 				Return:     returnType,
-				Visibility: visiblity,
+				Visibility: visibility,
 			})
 		}
 	}

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -428,7 +428,7 @@ func CompareSerializedEdge(edge, other *Edge) error {
 
 	if edge.LabelDimensions.Height != other.LabelDimensions.Height {
 		return fmt.Errorf(
-			"label hieght differs: edge=%d, other=%d",
+			"label height differs: edge=%d, other=%d",
 			edge.LabelDimensions.Height,
 			other.LabelDimensions.Height,
 		)

--- a/d2layouts/d2layoutfeatures/d2layoutfeatures.go
+++ b/d2layouts/d2layoutfeatures/d2layoutfeatures.go
@@ -1,6 +1,6 @@
 package d2layoutfeatures
 
-// When this is true, objects can set ther `near` key to another object
+// When this is true, objects can set their `near` key to another object
 // When this is false, objects can only set `near` to constants
 const NEAR_OBJECT = "near_object"
 

--- a/d2plugin/plugin_features.go
+++ b/d2plugin/plugin_features.go
@@ -8,7 +8,7 @@ import (
 
 type PluginFeature string
 
-// When this is true, objects can set ther `near` key to another object
+// When this is true, objects can set their `near` key to another object
 // When this is false, objects can only set `near` to constants
 const NEAR_OBJECT PluginFeature = "near_object"
 

--- a/d2renderers/d2fonts/README.md
+++ b/d2renderers/d2fonts/README.md
@@ -1,7 +1,7 @@
 # d2fonts
 
 The SVG renderer embeds fonts directly into the SVG as base64 data. This is to give
-determinstic outputs and load without a network call.
+deterministic outputs and load without a network call.
 
 To include your own font, e.g. `Helvetica`, you must include the Truetype glyphs:
 - `./ttf/Helvetica-Bold.ttf`

--- a/d2themes/sketch_overlay.go
+++ b/d2themes/sketch_overlay.go
@@ -19,7 +19,7 @@ func NewThemableSketchOverlay(el *ThemableElement, fill string) *ThemableSketchO
 }
 
 // TODO we can just call el.Copy() to prevent that
-// WARNING: Do not reuse the element afterwards as this function changes the Class propery
+// WARNING: Do not reuse the element afterwards as this function changes the Class property
 func (o *ThemableSketchOverlay) Render() (string, error) {
 	if color.IsThemeColor(o.fill) {
 		o.el.ClassName += fmt.Sprintf(" sketch-overlay-%s", o.fill) // e.g. sketch-overlay-B3

--- a/lib/geo/segment_test.go
+++ b/lib/geo/segment_test.go
@@ -20,7 +20,7 @@ func TestSegmentIntersections(t *testing.T) {
 	assert.Equal(t, len(intersections), 1)
 	assert.True(t, intersections[0].Equals(NewPoint(10, 10)))
 
-	// intersection at the beginnig
+	// intersection at the beginning
 	s4 := NewSegment(NewPoint(0, 0), NewPoint(0, 10))
 	intersections = s1.Intersections(*s4)
 	assert.Equal(t, len(intersections), 1)

--- a/lib/pdf/pdf.go
+++ b/lib/pdf/pdf.go
@@ -148,7 +148,7 @@ func (g *GoFPDF) AddPDFPage(png []byte, boardPath []string, themeID int64, fill 
 		}
 	}
 
-	// Draw header/img seperator
+	// Draw header/img separator
 	g.pdf.SetXY(headerMargin, headerHeight)
 	g.pdf.SetLineWidth(1)
 	if fillRGB.IsLight() {


### PR DESCRIPTION
The [go report card](https://goreportcard.com/report/oss.terrastruct.com/d2) for this project complains about misspellings in this project. This PR corrects this and fixes a few other typos on the way.