### PR TITLE
exports: Prevent exports over canvas max dimensions

### DIFF
--- a/lib/png/generate_png.js
+++ b/lib/png/generate_png.js
@@ -1,4 +1,4 @@
-async ({imgString, scale}) => {
+async ({ imgString, scale }) => {
   const tempImg = new Image();
   const loadImage = () => {
     return new Promise((resolve, reject) => {
@@ -13,6 +13,31 @@ async ({imgString, scale}) => {
   const canvas = document.createElement("canvas");
   canvas.width = img.width * scale;
   canvas.height = img.height * scale;
+
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
+  const MAX_DIMENSION = 32767;
+  const MAX_AREA = 268435456;
+
+  const ratio = img.width / img.height;
+  if (ratio > 1) {
+    if (canvas.width > MAX_DIMENSION) {
+      canvas.width = MAX_DIMENSION;
+      canvas.height = MAX_DIMENSION / ratio;
+    }
+  } else {
+    if (canvas.height > MAX_DIMENSION) {
+      canvas.height = MAX_DIMENSION;
+      canvas.width = MAX_DIMENSION * ratio;
+    }
+  }
+
+  const currentArea = canvas.width * canvas.height;
+  if (currentArea > MAX_AREA) {
+    const areaRatio = MAX_AREA / currentArea;
+    canvas.height = Math.floor(canvas.height * areaRatio);
+    canvas.width = Math.floor(canvas.width * areaRatio);
+  }
+
   const ctx = canvas.getContext("2d");
   if (!ctx) {
     return new Error("could not get canvas context");


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas, canvas has a max 32,767 for each dimension and a total area max of 268,435,456 pixels. 

Here is a generated png of the problematic d2 code before:
[demo.png.zip](https://github.com/terrastruct/d2/files/11226460/demo.png.zip)
I can't even upload the actual png because the file side is too big

Closes https://github.com/terrastruct/d2/issues/1093
closes #964 