### PR TITLE
refactor LabelWidth and LabelHeight to LabelDimensions

### DIFF
--- a/d2graph/d2graph.go
+++ b/d2graph/d2graph.go
@@ -98,8 +98,6 @@ type Object struct {
 
 	*geo.Box      `json:"box,omitempty"`
 	LabelPosition *string `json:"labelPosition,omitempty"`
-	LabelWidth    *int    `json:"labelWidth,omitempty"`
-	LabelHeight   *int    `json:"labelHeight,omitempty"`
 	IconPosition  *string `json:"iconPosition,omitempty"`
 
 	Class    *d2target.Class    `json:"class,omitempty"`
@@ -528,6 +526,18 @@ func (obj *Object) HasOutsideBottomLabel() bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func (obj *Object) HasLabel() bool {
+	if obj == nil || obj.Attributes == nil {
+		return false
+	}
+	switch obj.Attributes.Shape.Value {
+	case d2target.ShapeText, d2target.ShapeClass, d2target.ShapeSQLTable, d2target.ShapeCode:
+		return false
+	default:
+		return obj.Attributes.Label.Value != ""
 	}
 }
 
@@ -1381,16 +1391,6 @@ func (g *Graph) SetDimensions(mtexts []*d2target.MText, ruler *textmeasure.Ruler
 			return err
 		}
 		obj.LabelDimensions = *labelDims
-
-		switch dslShape {
-		case d2target.ShapeText, d2target.ShapeClass, d2target.ShapeSQLTable, d2target.ShapeCode:
-			// no labels
-		default:
-			if obj.Attributes.Label.Value != "" {
-				obj.LabelWidth = go2.Pointer(labelDims.Width)
-				obj.LabelHeight = go2.Pointer(labelDims.Height)
-			}
-		}
 
 		// if there is a desired width or height, fit to content box without inner label padding for smallest minimum size
 		withInnerLabelPadding := desiredWidth == 0 && desiredHeight == 0 &&

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -334,34 +334,20 @@ func CompareSerializedObject(obj, other *Object) error {
 		}
 	}
 
-	if obj.LabelWidth != nil {
-		if other.LabelWidth == nil {
-			return fmt.Errorf("other does not have a label width")
-		}
-		if *obj.LabelWidth != *other.LabelWidth {
-			return fmt.Errorf(
-				"label widths differ: obj=%d, other=%d",
-				*obj.LabelWidth,
-				*other.LabelWidth,
-			)
-		}
-	} else if other.LabelWidth != nil {
-		return fmt.Errorf("other should not have label width")
+	if obj.LabelDimensions.Width != other.LabelDimensions.Width {
+		return fmt.Errorf(
+			"label width differs: obj=%d, other=%d",
+			obj.LabelDimensions.Width,
+			other.LabelDimensions.Width,
+		)
 	}
 
-	if obj.LabelHeight != nil {
-		if other.LabelHeight == nil {
-			return fmt.Errorf("other does not have a label height")
-		}
-		if *obj.LabelHeight != *other.LabelHeight {
-			return fmt.Errorf(
-				"label heights differ: obj=%d, other=%d",
-				*obj.LabelHeight,
-				*other.LabelHeight,
-			)
-		}
-	} else if other.LabelHeight != nil {
-		return fmt.Errorf("other should not have label height")
+	if obj.LabelDimensions.Height != other.LabelDimensions.Height {
+		return fmt.Errorf(
+			"label height differs: obj=%d, other=%d",
+			obj.LabelDimensions.Height,
+			other.LabelDimensions.Height,
+		)
 	}
 
 	return nil

--- a/d2layouts/d2elklayout/layout.go
+++ b/d2layouts/d2elklayout/layout.go
@@ -208,11 +208,11 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 
 		height := obj.Height
 		width := obj.Width
-		if obj.LabelWidth != nil && obj.LabelHeight != nil {
+		if obj.HasLabel() {
 			if obj.HasOutsideBottomLabel() || obj.Attributes.Icon != nil {
-				height += float64(*obj.LabelHeight) + label.PADDING
+				height += float64(obj.LabelDimensions.Height) + label.PADDING
 			}
-			width = go2.Max(width, float64(*obj.LabelWidth))
+			width = go2.Max(width, float64(obj.LabelDimensions.Width))
 		}
 
 		n := &ELKNode{
@@ -249,8 +249,8 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 
 			if n.LayoutOptions.Padding == DefaultOpts.Padding {
 				labelHeight := 0
-				if obj.LabelHeight != nil {
-					labelHeight = *obj.LabelHeight + label.PADDING
+				if obj.HasLabel() {
+					labelHeight = obj.LabelDimensions.Height + label.PADDING
 				}
 
 				n.Height += 100 + float64(labelHeight)
@@ -281,11 +281,11 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 			}
 		}
 
-		if obj.LabelWidth != nil && obj.LabelHeight != nil {
+		if obj.HasLabel() {
 			n.Labels = append(n.Labels, &ELKLabel{
 				Text:   obj.Attributes.Label.Value,
-				Width:  float64(*obj.LabelWidth),
-				Height: float64(*obj.LabelHeight),
+				Width:  float64(obj.LabelDimensions.Width),
+				Height: float64(obj.LabelDimensions.Height),
 			})
 		}
 
@@ -391,12 +391,12 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 		obj.Width = n.Width
 		obj.Height = n.Height
 
-		if obj.LabelWidth != nil && obj.LabelHeight != nil {
+		if obj.HasLabel() {
 			if len(obj.ChildrenArray) > 0 {
 				obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
 			} else if obj.HasOutsideBottomLabel() {
 				obj.LabelPosition = go2.Pointer(string(label.OutsideBottomCenter))
-				obj.Height -= float64(*obj.LabelHeight) + label.PADDING
+				obj.Height -= float64(obj.LabelDimensions.Height) + label.PADDING
 			} else if obj.Attributes.Icon != nil {
 				obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
 			} else {

--- a/d2layouts/d2near/layout.go
+++ b/d2layouts/d2near/layout.go
@@ -111,22 +111,22 @@ func place(obj *d2graph.Object) (float64, float64) {
 		if strings.Contains(*obj.LabelPosition, "_TOP_") {
 			// label is on the top, and container is placed on the bottom
 			if strings.Contains(nearKeyStr, "bottom") {
-				y += float64(*obj.LabelHeight)
+				y += float64(obj.LabelDimensions.Height)
 			}
 		} else if strings.Contains(*obj.LabelPosition, "_LEFT_") {
 			// label is on the left, and container is placed on the right
 			if strings.Contains(nearKeyStr, "right") {
-				x += float64(*obj.LabelWidth)
+				x += float64(obj.LabelDimensions.Width)
 			}
 		} else if strings.Contains(*obj.LabelPosition, "_RIGHT_") {
 			// label is on the right, and container is placed on the left
 			if strings.Contains(nearKeyStr, "left") {
-				x -= float64(*obj.LabelWidth)
+				x -= float64(obj.LabelDimensions.Width)
 			}
 		} else if strings.Contains(*obj.LabelPosition, "_BOTTOM_") {
 			// label is on the bottom, and container is placed on the top
 			if strings.Contains(nearKeyStr, "top") {
-				y -= float64(*obj.LabelHeight)
+				y -= float64(obj.LabelDimensions.Height)
 			}
 		}
 	}
@@ -239,11 +239,11 @@ func boundingBox(g *d2graph.Graph) (tl, br *geo.Point) {
 			if obj.Attributes.Label.Value != "" && obj.LabelPosition != nil {
 				labelPosition := label.Position(*obj.LabelPosition)
 				if labelPosition.IsOutside() {
-					labelTL := labelPosition.GetPointOnBox(obj.Box, label.PADDING, float64(*obj.LabelWidth), float64(*obj.LabelHeight))
+					labelTL := labelPosition.GetPointOnBox(obj.Box, label.PADDING, float64(obj.LabelDimensions.Width), float64(obj.LabelDimensions.Height))
 					x1 = math.Min(x1, labelTL.X)
 					y1 = math.Min(y1, labelTL.Y)
-					x2 = math.Max(x2, labelTL.X+float64(*obj.LabelWidth))
-					y2 = math.Max(y2, labelTL.Y+float64(*obj.LabelHeight))
+					x2 = math.Max(x2, labelTL.X+float64(obj.LabelDimensions.Width))
+					y2 = math.Max(y2, labelTL.Y+float64(obj.LabelDimensions.Height))
 				}
 			}
 		}

--- a/d2layouts/d2sequence/sequence_diagram.go
+++ b/d2layouts/d2sequence/sequence_diagram.go
@@ -186,8 +186,8 @@ func newSequenceDiagram(objects []*d2graph.Object, messages []*d2graph.Edge) (*s
 
 	sd.yStep += VERTICAL_PAD
 	sd.maxActorHeight += VERTICAL_PAD
-	if sd.root.LabelHeight != nil {
-		sd.maxActorHeight += float64(*sd.root.LabelHeight)
+	if sd.root.HasLabel() {
+		sd.maxActorHeight += float64(sd.root.LabelDimensions.Height)
 	}
 
 	return sd, nil
@@ -282,11 +282,11 @@ func (sd *sequenceDiagram) placeGroup(group *d2graph.Object) {
 }
 
 func (sd *sequenceDiagram) adjustGroupLabel(group *d2graph.Object) {
-	if group.LabelHeight == nil {
+	if !group.HasLabel() {
 		return
 	}
 
-	heightAdd := (*group.LabelHeight + EDGE_GROUP_LABEL_PADDING) - GROUP_CONTAINER_PADDING
+	heightAdd := (group.LabelDimensions.Height + EDGE_GROUP_LABEL_PADDING) - GROUP_CONTAINER_PADDING
 	if heightAdd < 0 {
 		return
 	}
@@ -339,8 +339,8 @@ func (sd *sequenceDiagram) placeActors() {
 		if actor.HasOutsideBottomLabel() {
 			actor.LabelPosition = go2.Pointer(string(label.OutsideBottomCenter))
 			yOffset = sd.maxActorHeight - actor.Height
-			if actor.LabelHeight != nil {
-				yOffset -= float64(*actor.LabelHeight)
+			if actor.HasLabel() {
+				yOffset -= float64(actor.LabelDimensions.Height)
 			}
 		} else {
 			actor.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
@@ -381,8 +381,8 @@ func (sd *sequenceDiagram) addLifelineEdges() {
 	for _, actor := range sd.actors {
 		actorBottom := actor.Center()
 		actorBottom.Y = actor.TopLeft.Y + actor.Height
-		if *actor.LabelPosition == string(label.OutsideBottomCenter) && actor.LabelHeight != nil {
-			actorBottom.Y += float64(*actor.LabelHeight) + LIFELINE_LABEL_PAD
+		if *actor.LabelPosition == string(label.OutsideBottomCenter) && actor.HasLabel() {
+			actorBottom.Y += float64(actor.LabelDimensions.Height) + LIFELINE_LABEL_PAD
 		}
 		actorLifelineEnd := actor.Center()
 		actorLifelineEnd.Y = endY


### PR DESCRIPTION
## Summary

Refactors `d2graph.Object` to remove redundant fields `LabelWidth` and `LabelHeight` and use `LabelDimensions`.

## Details
- consistency with `d2graph.Edge` `LabelDimensions`
- replace long-range nil check assumptions with `HasLabel()`