### PR TITLE
wip: fix animate + appendix

### DIFF
--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -434,6 +434,7 @@ func compile(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, rende
 			return nil, false, err
 		}
 		var out []byte
+		println("\033[1;31m--- DEBUG:", "=======================", "\033[m")
 		if len(boards) > 0 {
 			out = boards[0]
 			if animateInterval > 0 {

--- a/d2renderers/d2animate/d2animate.go
+++ b/d2renderers/d2animate/d2animate.go
@@ -60,6 +60,7 @@ func Wrap(rootDiagram *d2target.Diagram, svgs [][]byte, renderOpts d2svg.RenderO
 	)
 	fmt.Fprint(buf, fitToScreenWrapperOpening)
 
+	println("\033[1;31m--- DEBUG:", "=======================", "\033[m")
 	innerOpening := fmt.Sprintf(`<svg id="d2-svg" width="%d" height="%d" viewBox="%d %d %d %d">`,
 		width, height, left, top, width, height)
 	fmt.Fprint(buf, innerOpening)

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -1719,6 +1719,7 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 	// generate style elements that will be appended to the SVG tag
 	upperBuf := &bytes.Buffer{}
 	if opts.MasterID == "" {
+		println("\033[1;31m--- DEBUG:", "=======================", "\033[m")
 		EmbedFonts(upperBuf, diagramHash, buf.String(), diagram.FontFamily, diagram.GetCorpus()) // EmbedFonts *must* run before `d2sketch.DefineFillPatterns`, but after all elements are appended to `buf`
 		themeStylesheet, err := ThemeCSS(diagramHash, themeID, darkThemeID)
 		if err != nil {

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -96,6 +96,17 @@ steps: {
 			},
 		},
 		{
+			name: "animate-appendix",
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "animation.d2", `a: {link: http://www.google.com}
+`)
+				err := runTestMain(t, ctx, dir, env, "--animate-interval=1400", "--force-appendix", "animation.d2")
+				assert.Success(t, err)
+				svg := readFile(t, dir, "animation.svg")
+				assert.Testdata(t, ".svg", svg)
+			},
+		},
+		{
 			name: "linked-path",
 			// TODO tempdir is random, resulting in different test results each time with the links
 			skip: true,


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

just added test. appendix code assumes there's opening and closing tags and modifies viewbox and stuff. will be annoying to fix