### PR TITLE
fix `style` validation

### DIFF
--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -210,8 +210,8 @@ func (c *compiler) compileField(obj *d2graph.Object, f *d2ir.Field) {
 		c.compileReserved(&obj.Attributes, f)
 		return
 	} else if f.Name == "style" {
-		if f.Map() == nil {
-			c.errorf(f.LastRef().AST(), `"style" expected to be set to a map, or contain an additional keyword like "style.opacity: 0.4"`)
+		if f.Map() == nil || len(f.Map().Fields) == 0 {
+			c.errorf(f.LastRef().AST(), `"style" expected to be set to a map of key-values, or contain an additional keyword like "style.opacity: 0.4"`)
 			return
 		}
 		c.compileStyle(&obj.Attributes, f.Map())

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -1700,7 +1700,13 @@ x.a.b`,
 			name: "tail-style",
 
 			text:   `myobj.style: 3`,
-			expErr: `d2/testdata/d2compiler/TestCompile/tail-style.d2:1:7: "style" expected to be set to a map, or contain an additional keyword like "style.opacity: 0.4"`,
+			expErr: `d2/testdata/d2compiler/TestCompile/tail-style.d2:1:7: "style" expected to be set to a map of key-values, or contain an additional keyword like "style.opacity: 0.4"`,
+		},
+		{
+			name: "tail-style-map",
+
+			text:   `myobj.style: {}`,
+			expErr: `d2/testdata/d2compiler/TestCompile/tail-style-map.d2:1:7: "style" expected to be set to a map of key-values, or contain an additional keyword like "style.opacity: 0.4"`,
 		},
 		{
 			name: "bad-style-nesting",

--- a/testdata/d2compiler/TestCompile/tail-style-map.exp.json
+++ b/testdata/d2compiler/TestCompile/tail-style-map.exp.json
@@ -1,0 +1,12 @@
+{
+  "graph": null,
+  "err": {
+    "ioerr": null,
+    "errs": [
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/tail-style-map.d2,0:6:6-0:11:11",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/tail-style-map.d2:1:7: \"style\" expected to be set to a map of key-values, or contain an additional keyword like \"style.opacity: 0.4\""
+      }
+    ]
+  }
+}

--- a/testdata/d2compiler/TestCompile/tail-style.exp.json
+++ b/testdata/d2compiler/TestCompile/tail-style.exp.json
@@ -5,7 +5,7 @@
     "errs": [
       {
         "range": "d2/testdata/d2compiler/TestCompile/tail-style.d2,0:6:6-0:11:11",
-        "errmsg": "d2/testdata/d2compiler/TestCompile/tail-style.d2:1:7: \"style\" expected to be set to a map, or contain an additional keyword like \"style.opacity: 0.4\""
+        "errmsg": "d2/testdata/d2compiler/TestCompile/tail-style.d2:1:7: \"style\" expected to be set to a map of key-values, or contain an additional keyword like \"style.opacity: 0.4\""
       }
     ]
   }


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

D2 shouldn't consider an empty map for `style` valid.

There's an edge case where you 
1. parse, have no errors
2. format, removes empty maps
3. compile, error due to `style` being standalone (the assumption is that by step 3, there are no more errors because the caller has already validated with `parse`, and `format` should never change that outcome).