### PR TITLE
d2oracle: fix underscores for move with descendant

### DIFF
--- a/d2oracle/edit.go
+++ b/d2oracle/edit.go
@@ -1629,12 +1629,7 @@ func move(g *d2graph.Graph, key, newKey string, includeDescendants bool) (*d2gra
 										return nil, err
 									}
 
-									resolvedObj, ok := resolvedParent.HasChild(resolvedScopeKey)
-									if !ok {
-										return nil, errors.New("underscore key does not exist")
-									}
-
-									newPath, err := pathFromScopeKey(g, &d2ast.Key{Key: d2ast.MakeKeyPath(resolvedObj.AbsIDArray())}, ak2)
+									newPath, err := pathFromScopeKey(g, &d2ast.Key{Key: d2ast.MakeKeyPath(append(resolvedParent.AbsIDArray(), resolvedScopeKey...))}, ak2)
 									if err != nil {
 										return nil, err
 									}
@@ -1648,11 +1643,7 @@ func move(g *d2graph.Graph, key, newKey string, includeDescendants bool) (*d2gra
 										return nil, err
 									}
 
-									resolvedObj, ok := resolvedParent.HasChild(resolvedScopeKey)
-									if !ok {
-										return nil, errors.New("underscore key does not exist")
-									}
-									newPath, err := pathFromScopeKey(g, &d2ast.Key{Key: d2ast.MakeKeyPath(resolvedObj.AbsIDArray())}, ak2)
+									newPath, err := pathFromScopeKey(g, &d2ast.Key{Key: d2ast.MakeKeyPath(append(resolvedParent.AbsIDArray(), resolvedScopeKey...))}, ak2)
 									if err != nil {
 										return nil, err
 									}
@@ -1664,11 +1655,7 @@ func move(g *d2graph.Graph, key, newKey string, includeDescendants bool) (*d2gra
 										return nil, err
 									}
 
-									resolvedObj, ok := resolvedParent.HasChild(resolvedScopeKey)
-									if !ok {
-										return nil, errors.New("underscore key does not exist")
-									}
-									newPath, err := pathFromScopeKey(g, &d2ast.Key{Key: d2ast.MakeKeyPath(resolvedObj.AbsIDArray())}, ak2)
+									newPath, err := pathFromScopeKey(g, &d2ast.Key{Key: d2ast.MakeKeyPath(append(resolvedParent.AbsIDArray(), resolvedScopeKey...))}, ak2)
 									if err != nil {
 										return nil, err
 									}

--- a/d2oracle/edit.go
+++ b/d2oracle/edit.go
@@ -185,7 +185,7 @@ func ReconnectEdge(g *d2graph.Graph, edgeKey string, srcKey, dstKey *string) (_ 
 		if src != nil {
 			srcmk, _ := d2parser.ParseMapKey(*srcKey)
 			ref.Edge.Src = srcmk.Key
-			newPath, err := pathFromScope(g, srcmk, ref.ScopeObj)
+			newPath, err := pathFromScopeObj(g, srcmk, ref.ScopeObj)
 			if err != nil {
 				return nil, err
 			}
@@ -194,7 +194,7 @@ func ReconnectEdge(g *d2graph.Graph, edgeKey string, srcKey, dstKey *string) (_ 
 		if dst != nil {
 			dstmk, _ := d2parser.ParseMapKey(*dstKey)
 			ref.Edge.Dst = dstmk.Key
-			newPath, err := pathFromScope(g, dstmk, ref.ScopeObj)
+			newPath, err := pathFromScopeObj(g, dstmk, ref.ScopeObj)
 			if err != nil {
 				return nil, err
 			}
@@ -221,7 +221,7 @@ func pathFromScopeKey(g *d2graph.Graph, key *d2ast.Key, scopeak []string) ([]*d2
 	return newPath, nil
 }
 
-func pathFromScope(g *d2graph.Graph, key *d2ast.Key, fromScope *d2graph.Object) ([]*d2ast.StringBox, error) {
+func pathFromScopeObj(g *d2graph.Graph, key *d2ast.Key, fromScope *d2graph.Object) ([]*d2ast.StringBox, error) {
 	// We don't want this to be underscore-resolved scope. We want to ignore underscores
 	var scopeak []string
 	if fromScope != g.Root {
@@ -1753,11 +1753,11 @@ func move(g *d2graph.Graph, key, newKey string, includeDescendants bool) (*d2gra
 			detachedMK := &d2ast.Key{
 				Key: cloneKey(ref.Key),
 			}
-			oldPath, err := pathFromScope(g, mk, ref.ScopeObj)
+			oldPath, err := pathFromScopeObj(g, mk, ref.ScopeObj)
 			if err != nil {
 				return nil, err
 			}
-			newPath, err := pathFromScope(g, mk2, ref.ScopeObj)
+			newPath, err := pathFromScopeObj(g, mk2, ref.ScopeObj)
 			if err != nil {
 				return nil, err
 			}
@@ -1788,7 +1788,7 @@ func move(g *d2graph.Graph, key, newKey string, includeDescendants bool) (*d2gra
 			// When moving a node connected to an edge, we have to ensure parents continue to exist
 			// e.g. the `c` out of `a.b.c -> ...`
 			// `a.b` needs to exist
-			newPath, err := pathFromScope(g, mk2, ref.ScopeObj)
+			newPath, err := pathFromScopeObj(g, mk2, ref.ScopeObj)
 			if err != nil {
 				return nil, err
 			}

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -4200,6 +4200,44 @@ github: {
 `,
 		},
 		{
+			name: "include_descendants_underscore_2",
+			text: `a: {
+  b: {
+    _.c
+  }
+}
+`,
+			key:                `a.b`,
+			newKey:             `b`,
+			includeDescendants: true,
+
+			exp: `a
+b: {
+  _.a.c
+}
+`,
+		},
+		{
+			name: "include_descendants_underscore_3",
+			text: `a: {
+  b: {
+    _.c -> d
+		_.c -> _.d
+  }
+}
+`,
+			key:                `a.b`,
+			newKey:             `b`,
+			includeDescendants: true,
+
+			exp: `a
+b: {
+  _.a.c -> d
+  _.a.c -> _.a.d
+}
+`,
+		},
+		{
 			name: "include_descendants_edge_ref_underscore",
 			text: `x
 z
@@ -6698,6 +6736,41 @@ b
   "(x -> y.z.a)[0]": "(x -> b.z.a)[0]",
   "y.z": "b.z",
   "y.z.a": "b.z.a"
+}`,
+		},
+		{
+			name: "include_descendants_underscore_2",
+			text: `a: {
+  b: {
+    _.c
+  }
+}
+`,
+			key:                `a.b`,
+			newKey:             `b`,
+			includeDescendants: true,
+
+			exp: `{
+  "a.b": "b"
+}`,
+		},
+		{
+			name: "include_descendants_underscore_3",
+			text: `a: {
+  b: {
+    _.c -> d
+		_.c -> _.d
+  }
+}
+`,
+			key:                `a.b`,
+			newKey:             `b`,
+			includeDescendants: true,
+
+			exp: `{
+  "a.(c -> b.d)[0]": "(a.c -> b.d)[0]",
+  "a.b": "b",
+  "a.b.d": "b.d"
 }`,
 		},
 		{

--- a/testdata/d2oracle/TestMove/include_descendants_underscore_2.exp.json
+++ b/testdata/d2oracle/TestMove/include_descendants_underscore_2.exp.json
@@ -1,0 +1,342 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,0:0:0-4:0:17",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,0:0:0-0:1:1",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {}
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,1:0:2-3:1:16",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,1:0:2-1:1:3",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,1:0:2-1:1:3",
+                    "value": [
+                      {
+                        "string": "b",
+                        "raw_string": "b"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,1:3:5-3:0:15",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:2:9-2:7:14",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:2:9-2:7:14",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:2:9-2:3:10",
+                              "value": [
+                                {
+                                  "string": "_",
+                                  "raw_string": "_"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:4:11-2:5:12",
+                              "value": [
+                                {
+                                  "string": "a",
+                                  "raw_string": "a"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:6:13-2:7:14",
+                              "value": [
+                                {
+                                  "string": "c",
+                                  "raw_string": "c"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": {
+          "value": ""
+        }
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "a",
+        "id_val": "a",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          },
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:2:9-2:7:14",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:2:9-2:3:10",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:4:11-2:5:12",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:6:13-2:7:14",
+                    "value": [
+                      {
+                        "string": "c",
+                        "raw_string": "c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 1,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "a"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "b",
+        "id_val": "b",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,1:0:2-1:1:3",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,1:0:2-1:1:3",
+                    "value": [
+                      {
+                        "string": "b",
+                        "raw_string": "b"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "b"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "c",
+        "id_val": "c",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:2:9-2:7:14",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:2:9-2:3:10",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:4:11-2:5:12",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_2.d2,2:6:13-2:7:14",
+                    "value": [
+                      {
+                        "string": "c",
+                        "raw_string": "c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 2,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "c"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": "<nil>"
+}

--- a/testdata/d2oracle/TestMove/include_descendants_underscore_3.exp.json
+++ b/testdata/d2oracle/TestMove/include_descendants_underscore_3.exp.json
@@ -1,0 +1,762 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,0:0:0-5:0:39",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,0:0:0-0:1:1",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {}
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,1:0:2-4:1:38",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,1:0:2-1:1:3",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,1:0:2-1:1:3",
+                    "value": [
+                      {
+                        "string": "b",
+                        "raw_string": "b"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,1:3:5-4:0:37",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:12:19",
+                      "edges": [
+                        {
+                          "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:12:19",
+                          "src": {
+                            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:7:14",
+                            "path": [
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:3:10",
+                                  "value": [
+                                    {
+                                      "string": "_",
+                                      "raw_string": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:4:11-2:5:12",
+                                  "value": [
+                                    {
+                                      "string": "a",
+                                      "raw_string": "a"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:6:13-2:7:14",
+                                  "value": [
+                                    {
+                                      "string": "c",
+                                      "raw_string": "c"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          "src_arrow": "",
+                          "dst": {
+                            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:11:18-2:12:19",
+                            "path": [
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:11:18-2:12:19",
+                                  "value": [
+                                    {
+                                      "string": "d",
+                                      "raw_string": "d"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          "dst_arrow": ">"
+                        }
+                      ],
+                      "primary": {},
+                      "value": {}
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:16:36",
+                      "edges": [
+                        {
+                          "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:16:36",
+                          "src": {
+                            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:7:27",
+                            "path": [
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:3:23",
+                                  "value": [
+                                    {
+                                      "string": "_",
+                                      "raw_string": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:4:24-3:5:25",
+                                  "value": [
+                                    {
+                                      "string": "a",
+                                      "raw_string": "a"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:6:26-3:7:27",
+                                  "value": [
+                                    {
+                                      "string": "c",
+                                      "raw_string": "c"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          "src_arrow": "",
+                          "dst": {
+                            "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:11:31-3:16:36",
+                            "path": [
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:11:31-3:12:32",
+                                  "value": [
+                                    {
+                                      "string": "_",
+                                      "raw_string": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:13:33-3:14:34",
+                                  "value": [
+                                    {
+                                      "string": "a",
+                                      "raw_string": "a"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:15:35-3:16:36",
+                                  "value": [
+                                    {
+                                      "string": "d",
+                                      "raw_string": "d"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          "dst_arrow": ">"
+                        }
+                      ],
+                      "primary": {},
+                      "value": {}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": {
+          "value": ""
+        }
+      },
+      "zIndex": 0
+    },
+    "edges": [
+      {
+        "index": 0,
+        "isCurve": false,
+        "src_arrow": false,
+        "dst_arrow": true,
+        "references": [
+          {
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": ""
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": ""
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "index": 0,
+        "isCurve": false,
+        "src_arrow": false,
+        "dst_arrow": true,
+        "references": [
+          {
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": ""
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": ""
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      }
+    ],
+    "objects": [
+      {
+        "id": "a",
+        "id_val": "a",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          },
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:7:14",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:3:10",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:4:11-2:5:12",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:6:13-2:7:14",
+                    "value": [
+                      {
+                        "string": "c",
+                        "raw_string": "c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 1,
+            "map_key_edge_index": 0
+          },
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:7:27",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:3:23",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:4:24-3:5:25",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:6:26-3:7:27",
+                    "value": [
+                      {
+                        "string": "c",
+                        "raw_string": "c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 1,
+            "map_key_edge_index": 0
+          },
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:11:31-3:16:36",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:11:31-3:12:32",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:13:33-3:14:34",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:15:35-3:16:36",
+                    "value": [
+                      {
+                        "string": "d",
+                        "raw_string": "d"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 1,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "a"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "b",
+        "id_val": "b",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,1:0:2-1:1:3",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,1:0:2-1:1:3",
+                    "value": [
+                      {
+                        "string": "b",
+                        "raw_string": "b"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "b"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "c",
+        "id_val": "c",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:7:14",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:2:9-2:3:10",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:4:11-2:5:12",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:6:13-2:7:14",
+                    "value": [
+                      {
+                        "string": "c",
+                        "raw_string": "c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 2,
+            "map_key_edge_index": 0
+          },
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:7:27",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:2:22-3:3:23",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:4:24-3:5:25",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:6:26-3:7:27",
+                    "value": [
+                      {
+                        "string": "c",
+                        "raw_string": "c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 2,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "c"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "d",
+        "id_val": "d",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:11:18-2:12:19",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,2:11:18-2:12:19",
+                    "value": [
+                      {
+                        "string": "d",
+                        "raw_string": "d"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "d"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "d",
+        "id_val": "d",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:11:31-3:16:36",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:11:31-3:12:32",
+                    "value": [
+                      {
+                        "string": "_",
+                        "raw_string": "_"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:13:33-3:14:34",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestMove/include_descendants_underscore_3.d2,3:15:35-3:16:36",
+                    "value": [
+                      {
+                        "string": "d",
+                        "raw_string": "d"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 2,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "d"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": {
+            "value": ""
+          }
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": "<nil>"
+}


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

covers the case where the ref being moved is a map with children nodes that have underscores