### PR TITLE
Docs: Add Emacd D2 mode to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ let us know and we'll be happy to include it here!
 - **Obsidian plugin**: [https://github.com/terrastruct/d2-obsidian](https://github.com/terrastruct/d2-obsidian)
 - **Slack app**: [https://d2lang.com/tour/slack](https://d2lang.com/tour/slack)
 - **Discord plugin**: [https://d2lang.com/tour/discord](https://d2lang.com/tour/discord)
+- **Emacs D2 Mode**: [https://github.com/andorsk/d2-mode](https://github.com/andorsk/d2-mode)
 
 ### Community plugins
 


### PR DESCRIPTION
This is a minor docs update with the Emacs mode I use to edit D2