### PR TITLE
check for overlaps to validate top left

### DIFF
--- a/d2graph/layout.go
+++ b/d2graph/layout.go
@@ -3,6 +3,8 @@ package d2graph
 import (
 	"strings"
 
+	"oss.terrastruct.com/d2/d2ast"
+	"oss.terrastruct.com/d2/d2parser"
 	"oss.terrastruct.com/d2/d2target"
 	"oss.terrastruct.com/d2/lib/geo"
 	"oss.terrastruct.com/d2/lib/label"
@@ -188,4 +190,27 @@ func (obj *Object) GetLabelTopLeft() *geo.Point {
 		float64(obj.LabelDimensions.Height),
 	)
 	return labelTL
+}
+
+type LayoutError struct {
+	Errors []d2ast.Error `json:"errs"`
+}
+
+func (le LayoutError) Empty() bool {
+	return len(le.Errors) == 0
+}
+
+func (le LayoutError) Error() string {
+	var sb strings.Builder
+	for i, err := range le.Errors {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(err.Error())
+	}
+	return sb.String()
+}
+
+func (g *Graph) errorf(n d2ast.Node, f string, v ...interface{}) {
+	g.err.Errors = append(g.err.Errors, d2parser.Errorf(n, f, v...).(d2ast.Error))
 }

--- a/d2lib/d2lib_test.go
+++ b/d2lib/d2lib_test.go
@@ -1,0 +1,89 @@
+package d2lib_test
+
+import (
+	"context"
+	"testing"
+
+	"oss.terrastruct.com/d2/d2graph"
+	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
+	"oss.terrastruct.com/d2/d2lib"
+	"oss.terrastruct.com/d2/lib/textmeasure"
+	"oss.terrastruct.com/util-go/assert"
+)
+
+func TestValidateTopLeft(t *testing.T) {
+	assertCompile(t, `
+container: {
+	a: {
+		top: 100
+		left: 100
+	}
+	b: {
+		top: 100
+		left: 100
+	}
+}
+`,
+		`4:3: invalid top/left overlapping with "b"
+8:3: invalid top/left overlapping with "a"`,
+	)
+
+	assertCompile(t, `
+container: {
+	a: {
+		top: 100
+		left: 100
+	}
+	b: {
+		top: 100
+		left: 200
+	}
+}
+`,
+		``,
+	)
+
+	assertCompile(t, `
+a: {
+	top: 100
+	left: 100
+}
+b: {
+	top: 101
+	left: 101
+}
+`,
+		`3:2: invalid top/left overlapping with "b"
+7:2: invalid top/left overlapping with "a"`,
+	)
+
+	assertCompile(t, `
+a: {
+	top: 100
+	left: 100
+}
+b: {
+	top: 99
+	left: 99
+}
+`,
+		`3:2: invalid top/left overlapping with "b"
+7:2: invalid top/left overlapping with "a"`,
+	)
+}
+
+func assertCompile(t *testing.T, text string, expErr string) {
+	ruler, _ := textmeasure.NewRuler()
+	defaultLayout := func(ctx context.Context, g *d2graph.Graph) error {
+		return d2dagrelayout.Layout(ctx, g, nil)
+	}
+	_, _, err := d2lib.Compile(context.Background(), text, &d2lib.CompileOptions{
+		Layout: defaultLayout,
+		Ruler:  ruler,
+	})
+	if expErr != "" {
+		assert.ErrorString(t, err, expErr)
+	} else {
+		assert.Success(t, err)
+	}
+}


### PR DESCRIPTION
## Summary

If `top` and `left` keywords are used incorrectly they can cause invalid overlaps which can lead to layout errors.
This adds validation to check that the `top` and `left` keywords do not guarantee a layout is impossible.

## Details
- check if objects in the same container will definitely overlap based on their `top` and `left` keywords and their initial dimensions
- Note: if container objects need to grow past their initial dimensions to fit descendants during layout they can still end up overlapping with to `top` and `left`, causing a layout error.
