### PR TITLE
fix(docs): correct ent2d2 url

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ let us know and we'll be happy to include it here!
 - **Mongo to D2**: [https://github.com/novuhq/mongo-to-D2](https://github.com/novuhq/mongo-to-D2)
 - **Pandoc filter**: [https://github.com/ram02z/d2-filter](https://github.com/ram02z/d2-filter)
 - **Logseq-D2**: [https://github.com/b-yp/logseq-d2](https://github.com/b-yp/logseq-d2)
-- **ent2d2**: [https://github.com/tmc/ent2d2](https://github.com/b-yp/logseq-d2)
+- **ent2d2**: [https://github.com/tmc/ent2d2](https://github.com/tmc/ent2d2)
 
 ### Misc
 


### PR DESCRIPTION
Simple documentation fix to adjust the ent2d2 community plugin URL to the correct one.