### PR TITLE
configure timeout with D2_TIMEOUT

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -1,5 +1,7 @@
 #### Features 🚀
 
+- Configure timeout value with D2_TIMEOUT env var. [#1392](https://github.com/terrastruct/d2/pull/1392)
+
 #### Improvements 🧹
 
 - Display version on CLI help invocation [#1400](https://github.com/terrastruct/d2/pull/1400)

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -112,6 +112,9 @@ Print debug logs.
 .It Fl -img-cache Ar true
 In watch mode, images used in icons are cached for subsequent compilations. This should be disabled if images might change
 .Ns .
+.It Fl -timeout Ar 120
+The number of seconds before d2 will timeout.
+.Ns .
 .It Fl h , -help
 Print usage information and exit.
 .It Fl v , -version

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -103,33 +103,41 @@ Set the diagram layout engine to the passed string. For a list of available opti
 .Ar layout
 .Ns .
 .It Fl b , -bundle Ar true
-Bundle all assets and layers into the output svg.
+Bundle all assets and layers into the output svg
+.Ns .
 .It Fl -force-appendix Ar false
 An appendix for tooltips and links is added to PNG exports since they are not interactive. Setting this to true adds an appendix to SVG exports as well
 .Ns .
 .It Fl d , -debug
-Print debug logs.
+Print debug logs
+.Ns .
 .It Fl -img-cache Ar true
 In watch mode, images used in icons are cached for subsequent compilations. This should be disabled if images might change
 .Ns .
 .It Fl -timeout Ar 120
-The maximum number of seconds that D2 runs for before timing out and exiting. When rendering a large diagram, it is recommended to increase this value.
+The maximum number of seconds that D2 runs for before timing out and exiting. When rendering a large diagram, it is recommended to increase this value
 .Ns .
 .It Fl h , -help
-Print usage information and exit.
+Print usage information and exit
+.Ns .
 .It Fl v , -version
-Print version information and exit.
+Print version information and exit
+.Ns .
 .El
 .Sh SUBCOMMANDS
 .Bl -tag -width Fl
 .It Ar layout
-Lists available layout engine options with short help.
+Lists available layout engine options with short help
+.Ns .
 .It Ar layout Op Ar name
-Display long help for a particular layout engine, including its configuration options.
+Display long help for a particular layout engine, including its configuration options
+.Ns .
 .It Ar themes
-Lists available themes.
+Lists available themes
+.Ns .
 .It Ar fmt Ar file.d2 ...
-Format all passed files.
+Format all passed files
+.Ns .
 .El
 .Sh SEE ALSO
 .Xr d2plugin-tala 1

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -113,7 +113,7 @@ Print debug logs.
 In watch mode, images used in icons are cached for subsequent compilations. This should be disabled if images might change
 .Ns .
 .It Fl -timeout Ar 120
-The number of seconds before d2 will timeout.
+The maximum number of seconds that D2 runs for before timing out and exiting. When rendering a large diagram, it is recommended to increase this value.
 .Ns .
 .It Fl h , -help
 Print usage information and exit.

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -31,6 +31,7 @@ import (
 	"oss.terrastruct.com/d2/d2themes"
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 	"oss.terrastruct.com/d2/lib/background"
+	"oss.terrastruct.com/d2/lib/env"
 	"oss.terrastruct.com/d2/lib/imgbundler"
 	ctxlog "oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/d2/lib/pdf"
@@ -298,8 +299,16 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		return w.run()
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
-	defer cancel()
+	timeout := time.Minute * 2
+	if seconds, has := env.Timeout(); has {
+		timeout = time.Duration(seconds) * time.Second
+	}
+
+	if timeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	_, written, err := compile(ctx, ms, plugin, renderOpts, fontFamily, *animateIntervalFlag, inputPath, outputPath, *bundleFlag, *forceAppendixFlag, pw.Page)
 	if err != nil {

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -89,7 +89,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	timeoutFlag, err := ms.Opts.Int64("D2_TIMEOUT", "timeout", "", 0, "the number of seconds before d2 will timeout. (default=120)")
+	timeoutFlag, err := ms.Opts.Int64("D2_TIMEOUT", "timeout", "", 120, "the number of seconds before d2 will timeout")
 	if err != nil {
 		return err
 	}

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -32,6 +32,7 @@ import (
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 	"oss.terrastruct.com/d2/lib/background"
 	"oss.terrastruct.com/d2/lib/imgbundler"
+	"oss.terrastruct.com/d2/lib/log"
 	ctxlog "oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/d2/lib/pdf"
 	"oss.terrastruct.com/d2/lib/png"
@@ -306,15 +307,8 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		return w.run()
 	}
 
-	timeout := time.Minute * 2
-	if timeoutFlag != nil {
-		timeout = time.Duration(*timeoutFlag) * time.Second
-	}
-	if timeout > 0 {
-		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
+	ctx, cancel := log.WithTimeout(ctx, time.Minute*2)
+	defer cancel()
 
 	_, written, err := compile(ctx, ms, plugin, renderOpts, fontFamily, *animateIntervalFlag, inputPath, outputPath, *bundleFlag, *forceAppendixFlag, pw.Page)
 	if err != nil {

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -89,7 +89,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	timeoutFlag, err := ms.Opts.Int64("D2_TIMEOUT", "timeout", "", 120, "the number of seconds before d2 will timeout")
+	timeoutFlag, err := ms.Opts.Int64("D2_TIMEOUT", "timeout", "", 120, "the maximum number of seconds that D2 runs for before timing out and exiting. When rendering a large diagram, it is recommended to increase this value")
 	if err != nil {
 		return err
 	}

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -89,7 +89,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	timeoutFlag, err := ms.Opts.Int64("D2_TIMEOUT", "timeout", "", 0, "the number of seconds before d2 will timeout. default is 60s.")
+	timeoutFlag, err := ms.Opts.Int64("D2_TIMEOUT", "timeout", "", 0, "the number of seconds before d2 will timeout. (default=120)")
 	if err != nil {
 		return err
 	}

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -32,12 +32,12 @@ import (
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 	"oss.terrastruct.com/d2/lib/background"
 	"oss.terrastruct.com/d2/lib/imgbundler"
-	"oss.terrastruct.com/d2/lib/log"
 	ctxlog "oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/d2/lib/pdf"
 	"oss.terrastruct.com/d2/lib/png"
 	"oss.terrastruct.com/d2/lib/pptx"
 	"oss.terrastruct.com/d2/lib/textmeasure"
+	timelib "oss.terrastruct.com/d2/lib/time"
 	"oss.terrastruct.com/d2/lib/version"
 	"oss.terrastruct.com/d2/lib/xgif"
 
@@ -307,7 +307,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		return w.run()
 	}
 
-	ctx, cancel := log.WithTimeout(ctx, time.Minute*2)
+	ctx, cancel := timelib.WithTimeout(ctx, time.Minute*2)
 	defer cancel()
 
 	_, written, err := compile(ctx, ms, plugin, renderOpts, fontFamily, *animateIntervalFlag, inputPath, outputPath, *bundleFlag, *forceAppendixFlag, pw.Page)

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -148,7 +148,7 @@ func (p *execPlugin) Info(ctx context.Context) (_ *PluginInfo, err error) {
 }
 
 func (p *execPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
-	ctx, cancel := timelib.WithTimeout(ctx, time.Minute)
+	ctx, cancel := timelib.WithTimeout(ctx, time.Minute*2)
 	defer cancel()
 
 	graphBytes, err := d2graph.SerializeGraph(g)

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -15,6 +15,7 @@ import (
 	"oss.terrastruct.com/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2graph"
+	"oss.terrastruct.com/d2/lib/env"
 )
 
 // execPlugin uses the binary at pathname with the plugin protocol to implement
@@ -147,8 +148,15 @@ func (p *execPlugin) Info(ctx context.Context) (_ *PluginInfo, err error) {
 }
 
 func (p *execPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
+	timeout := time.Minute
+	if seconds, has := env.Timeout(); has {
+		timeout = time.Duration(seconds) * time.Second
+	}
+	if timeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	graphBytes, err := d2graph.SerializeGraph(g)
 	if err != nil {

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -15,7 +15,7 @@ import (
 	"oss.terrastruct.com/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2graph"
-	"oss.terrastruct.com/d2/lib/env"
+	"oss.terrastruct.com/d2/lib/log"
 )
 
 // execPlugin uses the binary at pathname with the plugin protocol to implement
@@ -148,15 +148,8 @@ func (p *execPlugin) Info(ctx context.Context) (_ *PluginInfo, err error) {
 }
 
 func (p *execPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
-	timeout := time.Minute
-	if seconds, has := env.Timeout(); has {
-		timeout = time.Duration(seconds) * time.Second
-	}
-	if timeout > 0 {
-		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
+	ctx, cancel := log.WithTimeout(ctx, time.Minute)
+	defer cancel()
 
 	graphBytes, err := d2graph.SerializeGraph(g)
 	if err != nil {

--- a/d2plugin/exec.go
+++ b/d2plugin/exec.go
@@ -15,7 +15,7 @@ import (
 	"oss.terrastruct.com/util-go/xmain"
 
 	"oss.terrastruct.com/d2/d2graph"
-	"oss.terrastruct.com/d2/lib/log"
+	timelib "oss.terrastruct.com/d2/lib/time"
 )
 
 // execPlugin uses the binary at pathname with the plugin protocol to implement
@@ -148,7 +148,7 @@ func (p *execPlugin) Info(ctx context.Context) (_ *PluginInfo, err error) {
 }
 
 func (p *execPlugin) Layout(ctx context.Context, g *d2graph.Graph) error {
-	ctx, cancel := log.WithTimeout(ctx, time.Minute)
+	ctx, cancel := timelib.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	graphBytes, err := d2graph.SerializeGraph(g)

--- a/e2etests/report/main.go
+++ b/e2etests/report/main.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 	"time"
 
+	"oss.terrastruct.com/d2/lib/env"
 	"oss.terrastruct.com/d2/lib/log"
 )
 
@@ -69,8 +70,17 @@ func main() {
 
 	if !*skipTests {
 		ctx := log.Stderr(context.Background())
-		ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-		defer cancel()
+
+		timeout := 2 * time.Minute
+		if seconds, has := env.Timeout(); has {
+			timeout = time.Duration(seconds) * time.Second
+		}
+		if timeout > 0 {
+			var cancel func()
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+
 		// don't want to pass empty args to CommandContext
 		args := []string{"test", testDir, testMatchString}
 		if cpuProfileStr != "" {

--- a/e2etests/report/main.go
+++ b/e2etests/report/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"oss.terrastruct.com/d2/lib/log"
+	timelib "oss.terrastruct.com/d2/lib/time"
 )
 
 //go:embed template.html
@@ -70,7 +71,7 @@ func main() {
 	if !*skipTests {
 		ctx := log.Stderr(context.Background())
 
-		ctx, cancel := log.WithTimeout(ctx, 2*time.Minute)
+		ctx, cancel := timelib.WithTimeout(ctx, 2*time.Minute)
 		defer cancel()
 
 		// don't want to pass empty args to CommandContext

--- a/e2etests/report/main.go
+++ b/e2etests/report/main.go
@@ -15,7 +15,6 @@ import (
 	"text/template"
 	"time"
 
-	"oss.terrastruct.com/d2/lib/env"
 	"oss.terrastruct.com/d2/lib/log"
 )
 
@@ -71,15 +70,8 @@ func main() {
 	if !*skipTests {
 		ctx := log.Stderr(context.Background())
 
-		timeout := 2 * time.Minute
-		if seconds, has := env.Timeout(); has {
-			timeout = time.Duration(seconds) * time.Second
-		}
-		if timeout > 0 {
-			var cancel func()
-			ctx, cancel = context.WithTimeout(ctx, timeout)
-			defer cancel()
-		}
+		ctx, cancel := log.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
 
 		// don't want to pass empty args to CommandContext
 		args := []string{"test", testDir, testMatchString}

--- a/lib/env/env.go
+++ b/lib/env/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"os"
+	"strconv"
 )
 
 func Test() bool {
@@ -24,4 +25,14 @@ func DevOnly() bool {
 
 func SkipGraphDiffTests() bool {
 	return os.Getenv("SKIP_GRAPH_DIFF_TESTS") != ""
+}
+
+func Timeout() (int, bool) {
+	if s := os.Getenv("D2_TIMEOUT"); s != "" {
+		i, err := strconv.ParseInt(s, 10, 64)
+		if err == nil {
+			return int(i), true
+		}
+	}
+	return -1, false
 }

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime/debug"
 	"testing"
-	"time"
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
@@ -112,17 +111,4 @@ func Stderr(ctx context.Context) context.Context {
 	stdlog.SetOutput(sl.Writer())
 
 	return With(ctx, l)
-}
-
-// WithTimeout returns context.WithTimeout(ctx, timeout) but timeout is overridden with D2_TIMEOUT if set
-func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	t := timeout
-	if seconds, has := env.Timeout(); has {
-		t = time.Duration(seconds) * time.Second
-	}
-	if t <= 0 {
-		return ctx, func() {}
-	}
-
-	return context.WithTimeout(ctx, t)
 }

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime/debug"
 	"testing"
+	"time"
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
@@ -111,4 +112,17 @@ func Stderr(ctx context.Context) context.Context {
 	stdlog.SetOutput(sl.Writer())
 
 	return With(ctx, l)
+}
+
+// WithTimeout returns context.WithTimeout(ctx, timeout) but timeout is overridden with D2_TIMEOUT if set
+func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	t := timeout
+	if seconds, has := env.Timeout(); has {
+		t = time.Duration(seconds) * time.Second
+	}
+	if t <= 0 {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, t)
 }

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -1,0 +1,26 @@
+package time
+
+import (
+	"context"
+	"time"
+
+	"oss.terrastruct.com/d2/lib/env"
+)
+
+func HumanDate(t time.Time) string {
+	local := t.Local()
+	return local.Format(time.RFC822)
+}
+
+// WithTimeout returns context.WithTimeout(ctx, timeout) but timeout is overridden with D2_TIMEOUT if set
+func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	t := timeout
+	if seconds, has := env.Timeout(); has {
+		t = time.Duration(seconds) * time.Second
+	}
+	if t <= 0 {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, t)
+}


### PR DESCRIPTION
## Summary

For very large graphs we may want to configure d2 to run longer before timing out.

## Details
- e.g. use `D2_TIMEOUT=180 d2 ...` or `d2 --timeout 180 ...` to run d2 with a timeout after 3 minutes
- also applies to plugins' layout and e2ereport
