### PR TITLE
fix grid label font size in tala

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -9,3 +9,4 @@
 #### Bugfixes ⛑️
 
 - Fixes edge case in compiler using dots in quotes [#1401](https://github.com/terrastruct/d2/pull/1401)
+- Fixes grid label font size for TALA [#1412](https://github.com/terrastruct/d2/pull/1412)

--- a/d2graph/d2graph.go
+++ b/d2graph/d2graph.go
@@ -584,7 +584,8 @@ func (obj *Object) Text() *d2target.MText {
 	}
 
 	if obj.OuterSequenceDiagram() == nil {
-		if obj.IsContainer() && obj.Shape.Value != "text" {
+		// Note: during grid layout when children are temporarily removed `IsContainer` is false
+		if (obj.IsContainer() || obj.IsGridDiagram()) && obj.Shape.Value != "text" {
 			fontSize = obj.Level().LabelSize()
 		}
 	} else {


### PR DESCRIPTION
## Summary

Fixes an issue where `Object.Text` will return the wrong font-size if called during grid-layout.

## Details
- grid object temporarily has `Children` removed during layout, causing `isContainer` to return false at that time
- TALA reads this font-size to use during layout but it was giving the wrong result


### TALA before/after

![Screen Shot 2023-06-15 at 2 38 53 PM](https://github.com/terrastruct/d2/assets/85081687/76d008ae-b5e9-49d9-9db7-782545966f72)
