### PR TITLE
use scale flag for no-fit and customizing zoom

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -1,6 +1,7 @@
 #### Features 🚀
 
 - Configure timeout value with D2_TIMEOUT env var. [#1392](https://github.com/terrastruct/d2/pull/1392)
+- Scale renders and disable fit to screen with `--scale` flag. [#1413](https://github.com/terrastruct/d2/pull/1413)
 
 #### Improvements 🧹
 

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -80,7 +80,7 @@ Renders the diagram to look like it was sketched by hand
 .It Fl -center Ar flag
 Center the SVG in the containing viewbox, such as your browser screen
 .Ns .
-.It Fl -scale Ar fit
+.It Fl -scale Ar -1
 Set a fixed render scale (e.g. 0.5 to halve rendered size). If none provided, SVG will fit to screen
 .Ns .
 .It Fl -font-regular

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -81,7 +81,7 @@ Renders the diagram to look like it was sketched by hand
 Center the SVG in the containing viewbox, such as your browser screen
 .Ns .
 .It Fl -scale Ar -1
-Set a fixed render scale (e.g. 0.5 to halve rendered size). If none provided, SVG will fit to screen
+Scale the output. E.g., 0.5 to halve the default size. Default -1 means that SVG's will fit to screen and all others will use their default render size. Setting to 1 turns off SVG fitting to screen
 .Ns .
 .It Fl -font-regular
 Path to .ttf file to use for the regular font. If none provided, Source Sans Pro Regular is used

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -80,6 +80,9 @@ Renders the diagram to look like it was sketched by hand
 .It Fl -center Ar flag
 Center the SVG in the containing viewbox, such as your browser screen
 .Ns .
+.It Fl -scale Ar fit
+Set a fixed render scale (e.g. 0.5 to halve rendered size). If none provided, SVG will fit to screen
+.Ns .
 .It Fl -font-regular
 Path to .ttf file to use for the regular font. If none provided, Source Sans Pro Regular is used
 .Ns .

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -107,7 +107,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	scaleFlag, err := ms.Opts.Float64("SCALE", "scale", "", -1, "set a fixed render scale (e.g. 0.5 to halve rendered size). If none provided, SVG will fit to screen.")
+	scaleFlag, err := ms.Opts.Float64("SCALE", "scale", "", -1, "scale the output. E.g., 0.5 to halve the default size. Default -1 means that SVG's will fit to screen and all others will use their default render size. Setting to 1 turns off SVG fitting to screen.")
 	if err != nil {
 		return err
 	}

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -107,7 +107,10 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
-	scaleFlag := ms.Opts.String("SCALE", "scale", "", "fit", "set a fixed render scale (e.g. 0.5 to halve rendered size). If none provided, SVG will fit to screen.")
+	scaleFlag, err := ms.Opts.Float64("SCALE", "scale", "", -1, "set a fixed render scale (e.g. 0.5 to halve rendered size). If none provided, SVG will fit to screen.")
+	if err != nil {
+		return err
+	}
 
 	fontRegularFlag := ms.Opts.String("D2_FONT_REGULAR", "font-regular", "", "", "path to .ttf file to use for the regular font. If none provided, Source Sans Pro Regular is used.")
 	fontItalicFlag := ms.Opts.String("D2_FONT_ITALIC", "font-italic", "", "", "path to .ttf file to use for the italic font. If none provided, Source Sans Pro Regular-Italic is used.")
@@ -234,12 +237,8 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		ms.Log.Debug.Printf("using dark theme %s (ID: %d)", match.Name, *darkThemeFlag)
 	}
 	var scale *float64
-	if scaleFlag != nil && *scaleFlag != "fit" {
-		f, err := strconv.ParseFloat(*scaleFlag, 64)
-		if err != nil || f <= 0. {
-			return xmain.UsageErrorf("-scale must a positive floating point number or \"fit\".")
-		}
-		scale = &f
+	if scaleFlag != nil && *scaleFlag > 0. {
+		scale = scaleFlag
 	}
 
 	plugin, err := d2plugin.FindPlugin(ctx, ps, *layoutFlag)

--- a/d2cli/static/watch.js
+++ b/d2cli/static/watch.js
@@ -35,12 +35,16 @@ function init(reconnectDelay) {
       let width = parseInt(svgEl.getAttribute("width"), 10);
       let height = parseInt(svgEl.getAttribute("height"), 10);
       if (isInit) {
-        if (width > height) {
-          if (width > window.innerWidth) {
-            ratio = window.innerWidth / width;
+        if (msg.scale) {
+          ratio = msg.scale;
+        } else {
+          if (width > height) {
+            if (width > window.innerWidth) {
+              ratio = window.innerWidth / width;
+            }
+          } else if (height > window.innerHeight) {
+            ratio = window.innerHeight / height;
           }
-        } else if (height > window.innerHeight) {
-          ratio = window.innerHeight / height;
         }
         // Scale svg fit to zoom
         isInit = false;

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -83,8 +83,9 @@ type watcher struct {
 }
 
 type compileResult struct {
-	SVG string `json:"svg"`
-	Err string `json:"err"`
+	SVG   string   `json:"svg"`
+	Scale *float64 `json:"scale,omitEmpty"`
+	Err   string   `json:"err"`
 }
 
 func newWatcher(ctx context.Context, ms *xmain.State, opts watcherOpts) (*watcher, error) {
@@ -372,8 +373,9 @@ func (w *watcher) compileLoop(ctx context.Context) error {
 			w.ms.Log.Error.Print(errs)
 		}
 		w.broadcast(&compileResult{
-			SVG: string(svg),
-			Err: errs,
+			SVG:   string(svg),
+			Scale: w.renderOpts.Scale,
+			Err:   errs,
 		})
 
 		if firstCompile {

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -75,8 +75,8 @@ type RenderOpts struct {
 	ThemeID     int64
 	DarkThemeID *int64
 	Font        string
-	// disables the fit to screen behavior and ensures the exported svg has the exact dimensions
-	SetDimensions bool
+	// the svg will be scaled by this factor, if unset the svg will fit to screen
+	Scale *float64
 
 	// MasterID is passed when the diagram should use something other than its own hash for unique targeting
 	// Currently, that's when multi-boards are collapsed
@@ -1648,7 +1648,7 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 	pad := DEFAULT_PADDING
 	themeID := DEFAULT_THEME
 	darkThemeID := DEFAULT_DARK_THEME
-	setDimensions := false
+	var scale *float64
 	if opts != nil {
 		pad = opts.Pad
 		if opts.Sketch {
@@ -1660,7 +1660,7 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 		}
 		themeID = opts.ThemeID
 		darkThemeID = opts.DarkThemeID
-		setDimensions = opts.SetDimensions
+		scale = opts.Scale
 	}
 
 	buf := &bytes.Buffer{}
@@ -1851,8 +1851,11 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 	}
 
 	var dimensions string
-	if setDimensions {
-		dimensions = fmt.Sprintf(` width="%d" height="%d"`, w, h)
+	if scale != nil {
+		dimensions = fmt.Sprintf(` width="%d" height="%d"`,
+			int(math.Ceil((*scale)*float64(w))),
+			int(math.Ceil((*scale)*float64(h))),
+		)
 	}
 
 	alignment := "xMinYMin"


### PR DESCRIPTION
## Summary

Add `--scale` flag to replace `--no-fit` (`--scale=1`) and customize zoom.

## Details
- fixes #1080 
- covers the `--no-fit` functionality from #1346 and #721 with `scale=1`
- allows users to adjust "default zoom" without relying on browser zoom
- thanks to @bluemir for initial `--no-fit` setup


### e.g. scale=1

![Screen Shot 2023-06-15 at 4 56 35 PM](https://github.com/terrastruct/d2/assets/85081687/3fafeb70-ae6f-4807-827e-f8f0d54228ae)


### e.g. scale=0.5

![Screen Shot 2023-06-15 at 4 56 45 PM](https://github.com/terrastruct/d2/assets/85081687/e4155e53-a3d3-4046-878a-1ed28877f5bb)