### PR TITLE
use more efficient label position type

### DIFF
--- a/d2graph/d2graph.go
+++ b/d2graph/d2graph.go
@@ -1410,12 +1410,12 @@ func (g *Graph) SetDimensions(mtexts []*d2target.MText, ruler *textmeasure.Ruler
 		if obj.HasLabel() && obj.Attributes.LabelPosition != nil {
 			scalar := *obj.Attributes.LabelPosition
 			position := LabelPositionsMapping[scalar.Value]
-			obj.LabelPosition = go2.Pointer(string(position))
+			obj.LabelPosition = go2.Pointer(position.String())
 		}
 		if obj.Icon != nil && obj.Attributes.IconPosition != nil {
 			scalar := *obj.Attributes.IconPosition
 			position := LabelPositionsMapping[scalar.Value]
-			obj.IconPosition = go2.Pointer(string(position))
+			obj.IconPosition = go2.Pointer(position.String())
 		}
 
 		var desiredWidth int

--- a/d2graph/layout.go
+++ b/d2graph/layout.go
@@ -290,7 +290,7 @@ func (obj *Object) GetMargin() geo.Spacing {
 	margin := geo.Spacing{}
 
 	if obj.HasLabel() && obj.LabelPosition != nil {
-		position := label.Position(*obj.LabelPosition)
+		position := label.FromString(*obj.LabelPosition)
 
 		labelWidth := float64(obj.LabelDimensions.Width + label.PADDING)
 		labelHeight := float64(obj.LabelDimensions.Height + label.PADDING)
@@ -335,7 +335,7 @@ func (obj *Object) GetMargin() geo.Spacing {
 	}
 
 	if obj.Icon != nil && obj.IconPosition != nil && obj.Shape.Value != d2target.ShapeImage {
-		position := label.Position(*obj.IconPosition)
+		position := label.FromString(*obj.IconPosition)
 
 		iconSize := float64(d2target.MAX_ICON_SIZE + label.PADDING)
 		switch position {
@@ -373,7 +373,7 @@ func (obj *Object) GetLabelTopLeft() *geo.Point {
 	}
 
 	s := obj.ToShape()
-	labelPosition := label.Position(*obj.LabelPosition)
+	labelPosition := label.FromString(*obj.LabelPosition)
 
 	var box *geo.Box
 	if labelPosition.IsOutside() {
@@ -395,7 +395,7 @@ func (obj *Object) GetIconTopLeft() *geo.Point {
 	}
 
 	s := obj.ToShape()
-	iconPosition := label.Position(*obj.IconPosition)
+	iconPosition := label.FromString(*obj.IconPosition)
 
 	var box *geo.Box
 	if iconPosition.IsOutside() {
@@ -416,7 +416,7 @@ func (edge *Edge) TraceToShape(points []*geo.Point, startIndex, endIndex int) (n
 	overlapsOutsideLabel := false
 	if edge.Src.HasLabel() {
 		// assumes LabelPosition, LabelWidth, LabelHeight are all set if there is a label
-		labelPosition := label.Position(*edge.Src.LabelPosition)
+		labelPosition := label.FromString(*edge.Src.LabelPosition)
 		if labelPosition.IsOutside() {
 			labelWidth := float64(edge.Src.LabelDimensions.Width)
 			labelHeight := float64(edge.Src.LabelDimensions.Height)
@@ -467,7 +467,7 @@ func (edge *Edge) TraceToShape(points []*geo.Point, startIndex, endIndex int) (n
 	overlapsOutsideLabel = false
 	if edge.Dst.HasLabel() {
 		// assumes LabelPosition, LabelWidth, LabelHeight are all set if there is a label
-		labelPosition := label.Position(*edge.Dst.LabelPosition)
+		labelPosition := label.FromString(*edge.Dst.LabelPosition)
 		if labelPosition.IsOutside() {
 			labelWidth := float64(edge.Dst.LabelDimensions.Width)
 			labelHeight := float64(edge.Dst.LabelDimensions.Height)

--- a/d2layouts/d2dagrelayout/layout.go
+++ b/d2layouts/d2dagrelayout/layout.go
@@ -361,7 +361,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 		edge.Route = path
 		// compile needs to assign edge label positions
 		if edge.Label.Value != "" {
-			edge.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			edge.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 
 		// undo 3d/multiple offset
@@ -554,7 +554,7 @@ func getSpacing(obj *d2graph.Object) (margin, padding spacing) {
 	if obj.HasLabel() {
 		var position label.Position
 		if obj.LabelPosition != nil {
-			position = label.Position(*obj.LabelPosition)
+			position = label.FromString(*obj.LabelPosition)
 		} else if len(obj.ChildrenArray) == 0 && obj.HasOutsideBottomLabel() {
 			position = label.OutsideBottomCenter
 		}
@@ -585,7 +585,7 @@ func getSpacing(obj *d2graph.Object) (margin, padding spacing) {
 	if obj.Icon != nil && obj.Shape.Value != d2target.ShapeImage {
 		var position label.Position
 		if obj.IconPosition != nil {
-			position = label.Position(*obj.IconPosition)
+			position = label.FromString(*obj.IconPosition)
 		}
 
 		iconSize := float64(d2target.MAX_ICON_SIZE + 2*label.PADDING)
@@ -619,24 +619,24 @@ func getSpacing(obj *d2graph.Object) (margin, padding spacing) {
 func positionLabelsIcons(obj *d2graph.Object) {
 	if obj.Icon != nil && obj.IconPosition == nil {
 		if len(obj.ChildrenArray) > 0 {
-			obj.IconPosition = go2.Pointer(string(label.OutsideTopLeft))
+			obj.IconPosition = go2.Pointer(label.OutsideTopLeft.String())
 			if obj.LabelPosition == nil {
-				obj.LabelPosition = go2.Pointer(string(label.OutsideTopRight))
+				obj.LabelPosition = go2.Pointer(label.OutsideTopRight.String())
 				return
 			}
 		} else {
-			obj.IconPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			obj.IconPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 	}
 	if obj.HasLabel() && obj.LabelPosition == nil {
 		if len(obj.ChildrenArray) > 0 {
-			obj.LabelPosition = go2.Pointer(string(label.OutsideTopCenter))
+			obj.LabelPosition = go2.Pointer(label.OutsideTopCenter.String())
 		} else if obj.HasOutsideBottomLabel() {
-			obj.LabelPosition = go2.Pointer(string(label.OutsideBottomCenter))
+			obj.LabelPosition = go2.Pointer(label.OutsideBottomCenter.String())
 		} else if obj.Icon != nil {
-			obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
+			obj.LabelPosition = go2.Pointer(label.InsideTopCenter.String())
 		} else {
-			obj.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			obj.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 	}
 }
@@ -1408,7 +1408,7 @@ func fitPadding(obj *d2graph.Object) {
 	var labelPosition, iconPosition label.Position
 	var labelBox, iconBox *geo.Box
 	if obj.HasLabel() && obj.LabelPosition != nil {
-		labelPosition = label.Position(*obj.LabelPosition)
+		labelPosition = label.FromString(*obj.LabelPosition)
 		switch labelPosition {
 		case label.InsideTopLeft, label.InsideTopCenter, label.InsideTopRight,
 			label.InsideBottomLeft, label.InsideBottomCenter, label.InsideBottomRight,
@@ -1420,7 +1420,7 @@ func fitPadding(obj *d2graph.Object) {
 		}
 	}
 	if obj.Icon != nil && shapeType != shape.IMAGE_TYPE && obj.IconPosition != nil {
-		iconPosition = label.Position(*obj.IconPosition)
+		iconPosition = label.FromString(*obj.IconPosition)
 		switch iconPosition {
 		case label.InsideTopLeft, label.InsideTopCenter, label.InsideTopRight,
 			label.InsideBottomLeft, label.InsideBottomCenter, label.InsideBottomRight,
@@ -1442,7 +1442,7 @@ func fitPadding(obj *d2graph.Object) {
 			var childLabelBox *geo.Box
 			var childLabelPosition, childIconPosition label.Position
 			if child.HasLabel() && child.LabelPosition != nil {
-				childLabelPosition = label.Position(*child.LabelPosition)
+				childLabelPosition = label.FromString(*child.LabelPosition)
 				if childLabelPosition.IsOutside() {
 					childLabelTL := child.GetLabelTopLeft()
 
@@ -1455,7 +1455,7 @@ func fitPadding(obj *d2graph.Object) {
 				}
 			}
 			if child.Icon != nil && child.Shape.Value != d2target.ShapeImage && child.IconPosition != nil {
-				childIconPosition = label.Position(*child.IconPosition)
+				childIconPosition = label.FromString(*child.IconPosition)
 				if childIconPosition.IsOutside() {
 					childIconTL := child.GetIconTopLeft()
 
@@ -1480,7 +1480,7 @@ func fitPadding(obj *d2graph.Object) {
 		if edge.Label.Value != "" {
 			labelPosition := label.InsideMiddleCenter
 			if edge.LabelPosition != nil {
-				labelPosition = label.Position(*edge.LabelPosition)
+				labelPosition = label.FromString(*edge.LabelPosition)
 			}
 			labelWidth := float64(edge.LabelDimensions.Width)
 			labelHeight := float64(edge.LabelDimensions.Height)

--- a/d2layouts/d2elklayout/layout.go
+++ b/d2layouts/d2elklayout/layout.go
@@ -360,7 +360,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 				continue
 			}
 
-			switch label.Position(*child.IconPosition) {
+			switch label.FromString(*child.IconPosition) {
 			case label.OutsideTopLeft, label.OutsideTopCenter, label.OutsideTopRight:
 				hasTop = true
 			case label.OutsideBottomLeft, label.OutsideBottomCenter, label.OutsideBottomRight:
@@ -605,7 +605,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, opts *ConfigurableOpts) (err 
 		points = points[startIndex : endIndex+1]
 
 		if edge.Label.Value != "" {
-			edge.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			edge.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 
 		edge.Route = points
@@ -1003,7 +1003,7 @@ func adjustPadding(obj *d2graph.Object, width, height float64, padding shapePadd
 	if obj.HasLabel() && obj.LabelPosition != nil {
 		labelHeight := obj.LabelDimensions.Height + 2*label.PADDING
 		labelWidth := obj.LabelDimensions.Width + 2*label.PADDING
-		switch label.Position(*obj.LabelPosition) {
+		switch label.FromString(*obj.LabelPosition) {
 		case label.InsideTopLeft, label.InsideTopCenter, label.InsideTopRight:
 			// Note: for corners we only add height
 			extraTop = labelHeight
@@ -1017,7 +1017,7 @@ func adjustPadding(obj *d2graph.Object, width, height float64, padding shapePadd
 	}
 	if obj.Icon != nil && obj.Shape.Value != d2target.ShapeImage && obj.IconPosition != nil {
 		iconSize := d2target.MAX_ICON_SIZE + 2*label.PADDING
-		switch label.Position(*obj.IconPosition) {
+		switch label.FromString(*obj.IconPosition) {
 		case label.InsideTopLeft, label.InsideTopCenter, label.InsideTopRight:
 			extraTop = go2.Max(extraTop, iconSize)
 		case label.InsideBottomLeft, label.InsideBottomCenter, label.InsideBottomRight:
@@ -1093,7 +1093,7 @@ func adjustDimensions(obj *d2graph.Object) (width, height float64) {
 	if obj.HasLabel() {
 		var position label.Position
 		if obj.LabelPosition != nil {
-			position = label.Position(*obj.LabelPosition)
+			position = label.FromString(*obj.LabelPosition)
 		} else if len(obj.ChildrenArray) == 0 && obj.HasOutsideBottomLabel() {
 			position = label.OutsideBottomCenter
 		}
@@ -1118,7 +1118,7 @@ func adjustDimensions(obj *d2graph.Object) (width, height float64) {
 	if obj.Icon != nil && obj.Shape.Value != d2target.ShapeImage {
 		var position label.Position
 		if obj.IconPosition != nil {
-			position = label.Position(*obj.IconPosition)
+			position = label.FromString(*obj.IconPosition)
 		}
 
 		if position.IsShapePosition() {
@@ -1143,7 +1143,7 @@ func adjustDimensions(obj *d2graph.Object) (width, height float64) {
 func cleanupAdjustment(obj *d2graph.Object) {
 	// adjust size and position to account for space reserved for labels
 	if obj.HasLabel() {
-		position := label.Position(*obj.LabelPosition)
+		position := label.FromString(*obj.LabelPosition)
 		if position.IsShapePosition() {
 			var labelWidth float64
 			switch position {
@@ -1162,7 +1162,7 @@ func cleanupAdjustment(obj *d2graph.Object) {
 		}
 	}
 	if obj.Icon != nil && obj.Shape.Value != d2target.ShapeImage {
-		position := label.Position(*obj.IconPosition)
+		position := label.FromString(*obj.IconPosition)
 		if position.IsShapePosition() {
 			var iconWidth float64
 			switch position {
@@ -1202,24 +1202,24 @@ func cleanupAdjustment(obj *d2graph.Object) {
 func positionLabelsIcons(obj *d2graph.Object) {
 	if obj.Icon != nil && obj.IconPosition == nil {
 		if len(obj.ChildrenArray) > 0 {
-			obj.IconPosition = go2.Pointer(string(label.InsideTopLeft))
+			obj.IconPosition = go2.Pointer(label.InsideTopLeft.String())
 			if obj.LabelPosition == nil {
-				obj.LabelPosition = go2.Pointer(string(label.InsideTopRight))
+				obj.LabelPosition = go2.Pointer(label.InsideTopRight.String())
 				return
 			}
 		} else {
-			obj.IconPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			obj.IconPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 	}
 	if obj.HasLabel() && obj.LabelPosition == nil {
 		if len(obj.ChildrenArray) > 0 {
-			obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
+			obj.LabelPosition = go2.Pointer(label.InsideTopCenter.String())
 		} else if obj.HasOutsideBottomLabel() {
-			obj.LabelPosition = go2.Pointer(string(label.OutsideBottomCenter))
+			obj.LabelPosition = go2.Pointer(label.OutsideBottomCenter.String())
 		} else if obj.Icon != nil {
-			obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
+			obj.LabelPosition = go2.Pointer(label.InsideTopCenter.String())
 		} else {
-			obj.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			obj.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 	}
 }

--- a/d2layouts/d2grid/layout.go
+++ b/d2layouts/d2grid/layout.go
@@ -90,10 +90,10 @@ func Layout(ctx context.Context, g *d2graph.Graph) error {
 	}
 
 	if obj.HasLabel() {
-		obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
+		obj.LabelPosition = go2.Pointer(label.InsideTopCenter.String())
 	}
 	if obj.Icon != nil {
-		obj.IconPosition = go2.Pointer(string(label.InsideTopLeft))
+		obj.IconPosition = go2.Pointer(label.InsideTopLeft.String())
 	}
 
 	// simple straight line edge routing between grid objects
@@ -111,7 +111,7 @@ func Layout(ctx context.Context, g *d2graph.Graph) error {
 		e.Route = []*geo.Point{e.Src.Center(), e.Dst.Center()}
 		e.TraceToShape(e.Route, 0, 1)
 		if e.Label.Value != "" {
-			e.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			e.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 	}
 
@@ -119,7 +119,7 @@ func Layout(ctx context.Context, g *d2graph.Graph) error {
 		g.Root.TopLeft = geo.NewPoint(0, 0)
 	}
 
-	obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
+	obj.LabelPosition = go2.Pointer(label.InsideTopCenter.String())
 
 	if g.RootLevel > 0 {
 		horizontalPadding, verticalPadding := CONTAINER_PADDING, CONTAINER_PADDING
@@ -147,25 +147,25 @@ func layoutGrid(g *d2graph.Graph, obj *d2graph.Object) (*gridDiagram, error) {
 		positionedLabel := false
 		if o.Icon != nil && o.IconPosition == nil {
 			if len(o.ChildrenArray) > 0 {
-				o.IconPosition = go2.Pointer(string(label.OutsideTopLeft))
+				o.IconPosition = go2.Pointer(label.OutsideTopLeft.String())
 				// don't overwrite position if nested graph layout positioned label/icon
 				if o.LabelPosition == nil {
-					o.LabelPosition = go2.Pointer(string(label.OutsideTopRight))
+					o.LabelPosition = go2.Pointer(label.OutsideTopRight.String())
 					positionedLabel = true
 				}
 			} else {
-				o.IconPosition = go2.Pointer(string(label.InsideMiddleCenter))
+				o.IconPosition = go2.Pointer(label.InsideMiddleCenter.String())
 			}
 		}
 		if !positionedLabel && o.HasLabel() && o.LabelPosition == nil {
 			if len(o.ChildrenArray) > 0 {
-				o.LabelPosition = go2.Pointer(string(label.OutsideTopCenter))
+				o.LabelPosition = go2.Pointer(label.OutsideTopCenter.String())
 			} else if o.HasOutsideBottomLabel() {
-				o.LabelPosition = go2.Pointer(string(label.OutsideBottomCenter))
+				o.LabelPosition = go2.Pointer(label.OutsideBottomCenter.String())
 			} else if o.Icon != nil {
-				o.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
+				o.LabelPosition = go2.Pointer(label.InsideTopCenter.String())
 			} else {
-				o.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+				o.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 			}
 		}
 	}

--- a/d2layouts/d2layouts.go
+++ b/d2layouts/d2layouts.go
@@ -275,7 +275,7 @@ func LayoutNested(ctx context.Context, g *d2graph.Graph, graphInfo GraphInfo, co
 		e.Route = []*geo.Point{e.Src.Center(), e.Dst.Center()}
 		e.TraceToShape(e.Route, 0, 1)
 		if e.Label.Value != "" {
-			e.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			e.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 	}
 

--- a/d2layouts/d2near/layout.go
+++ b/d2layouts/d2near/layout.go
@@ -178,7 +178,7 @@ func boundingBox(g *d2graph.Graph) (tl, br *geo.Point) {
 			x2 = math.Max(x2, obj.TopLeft.X+obj.Width)
 			y2 = math.Max(y2, obj.TopLeft.Y+obj.Height)
 			if obj.Label.Value != "" && obj.LabelPosition != nil {
-				labelPosition := label.Position(*obj.LabelPosition)
+				labelPosition := label.FromString(*obj.LabelPosition)
 				if labelPosition.IsOutside() {
 					labelTL := labelPosition.GetPointOnBox(obj.Box, label.PADDING, float64(obj.LabelDimensions.Width), float64(obj.LabelDimensions.Height))
 					x1 = math.Min(x1, labelTL.X)

--- a/d2layouts/d2sequence/layout.go
+++ b/d2layouts/d2sequence/layout.go
@@ -32,7 +32,7 @@ func Layout(ctx context.Context, g *d2graph.Graph, layout d2graph.LayoutGraph) e
 
 	obj := g.Root
 
-	obj.LabelPosition = go2.Pointer(string(label.InsideTopCenter))
+	obj.LabelPosition = go2.Pointer(label.InsideTopCenter.String())
 
 	// shift the sequence diagrams as they are always placed at (0, 0) with some padding
 	sd.shift(

--- a/d2layouts/d2sequence/layout_test.go
+++ b/d2layouts/d2sequence/layout_test.go
@@ -141,12 +141,12 @@ n2 -> n1
 	}
 
 	// check label positions
-	if *g.Edges[0].LabelPosition != string(label.InsideMiddleCenter) {
-		t.Fatalf("expected edge label to be placed on %s, got %s", string(label.InsideMiddleCenter), *g.Edges[0].LabelPosition)
+	if *g.Edges[0].LabelPosition != label.InsideMiddleCenter.String() {
+		t.Fatalf("expected edge label to be placed on %s, got %s", label.InsideMiddleCenter, *g.Edges[0].LabelPosition)
 	}
 
-	if *g.Edges[1].LabelPosition != string(label.InsideMiddleCenter) {
-		t.Fatalf("expected edge label to be placed on %s, got %s", string(label.InsideMiddleCenter), *g.Edges[0].LabelPosition)
+	if *g.Edges[1].LabelPosition != label.InsideMiddleCenter.String() {
+		t.Fatalf("expected edge label to be placed on %s, got %s", label.InsideMiddleCenter, *g.Edges[0].LabelPosition)
 	}
 }
 

--- a/d2layouts/d2sequence/sequence_diagram.go
+++ b/d2layouts/d2sequence/sequence_diagram.go
@@ -76,7 +76,7 @@ func newSequenceDiagram(objects []*d2graph.Object, messages []*d2graph.Edge) (*s
 			// Groups may have more nested groups
 			for len(queue) > 0 {
 				curr := queue[0]
-				curr.LabelPosition = go2.Pointer(string(label.InsideTopLeft))
+				curr.LabelPosition = go2.Pointer(label.InsideTopLeft.String())
 				groups = append(groups, curr)
 				queue = queue[1:]
 				queue = append(queue, curr.ChildrenArray...)
@@ -135,7 +135,7 @@ func newSequenceDiagram(objects []*d2graph.Object, messages []*d2graph.Edge) (*s
 				child.Shape = d2graph.Scalar{Value: shape.PAGE_TYPE}
 				sd.notes = append(sd.notes, child)
 				sd.objectRank[child] = rank
-				child.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+				child.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 				maxNoteWidth = math.Max(maxNoteWidth, child.Width)
 			} else {
 				// spans have no labels
@@ -338,13 +338,13 @@ func (sd *sequenceDiagram) placeActors() {
 	for rank, actor := range sd.actors {
 		var yOffset float64
 		if actor.HasOutsideBottomLabel() {
-			actor.LabelPosition = go2.Pointer(string(label.OutsideBottomCenter))
+			actor.LabelPosition = go2.Pointer(label.OutsideBottomCenter.String())
 			yOffset = sd.maxActorHeight - actor.Height
 			if actor.HasLabel() {
 				yOffset -= float64(actor.LabelDimensions.Height)
 			}
 		} else {
-			actor.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			actor.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 			yOffset = sd.maxActorHeight - actor.Height
 		}
 		halfWidth := actor.Width / 2.
@@ -382,7 +382,7 @@ func (sd *sequenceDiagram) addLifelineEdges() {
 	for _, actor := range sd.actors {
 		actorBottom := actor.Center()
 		actorBottom.Y = actor.TopLeft.Y + actor.Height
-		if *actor.LabelPosition == string(label.OutsideBottomCenter) && actor.HasLabel() {
+		if *actor.LabelPosition == label.OutsideBottomCenter.String() && actor.HasLabel() {
 			actorBottom.Y += float64(actor.LabelDimensions.Height) + LIFELINE_LABEL_PAD
 		}
 		actorLifelineEnd := actor.Center()
@@ -602,7 +602,7 @@ func (sd *sequenceDiagram) routeMessages() error {
 		messageOffset += sd.yStep
 
 		if message.Label.Value != "" {
-			message.LabelPosition = go2.Pointer(string(label.InsideMiddleCenter))
+			message.LabelPosition = go2.Pointer(label.InsideMiddleCenter.String())
 		}
 	}
 	return nil

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -514,7 +514,7 @@ func drawConnection(writer io.Writer, labelMaskID string, connection d2target.Co
 		labelTL.X = math.Round(labelTL.X)
 		labelTL.Y = math.Round(labelTL.Y)
 
-		if label.Position(connection.LabelPosition).IsOnEdge() {
+		if label.FromString(connection.LabelPosition).IsOnEdge() {
 			labelMask = makeLabelMask(labelTL, connection.LabelWidth, connection.LabelHeight, 1)
 		} else {
 			labelMask = makeLabelMask(labelTL, connection.LabelWidth, connection.LabelHeight, 0.75)
@@ -1178,7 +1178,7 @@ func drawShape(writer, appendixWriter io.Writer, diagramHash string, targetShape
 	fmt.Fprint(writer, `</g>`)
 
 	if targetShape.Icon != nil && targetShape.Type != d2target.ShapeImage {
-		iconPosition := label.Position(targetShape.IconPosition)
+		iconPosition := label.FromString(targetShape.IconPosition)
 		var box *geo.Box
 		if iconPosition.IsOutside() {
 			box = s.GetBox()
@@ -1199,7 +1199,7 @@ func drawShape(writer, appendixWriter io.Writer, diagramHash string, targetShape
 	}
 
 	if targetShape.Label != "" {
-		labelPosition := label.Position(targetShape.LabelPosition)
+		labelPosition := label.FromString(targetShape.LabelPosition)
 		var box *geo.Box
 		if labelPosition.IsOutside() {
 			box = s.GetBox().Copy()

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -291,7 +291,7 @@ func (diagram Diagram) BoundingBox() (topLeft, bottomRight Point) {
 			x2 = go2.Max(x2, targetShape.Pos.X+MULTIPLE_OFFSET+targetShape.Width+targetShape.StrokeWidth)
 		}
 
-		if targetShape.Icon != nil && label.Position(targetShape.IconPosition).IsOutside() {
+		if targetShape.Icon != nil && label.FromString(targetShape.IconPosition).IsOutside() {
 			contentBox := geo.NewBox(geo.NewPoint(0, 0), float64(targetShape.Width), float64(targetShape.Height))
 			s := shape.NewShape(targetShape.Type, contentBox)
 			size := GetIconSize(s.GetInnerBox(), targetShape.IconPosition)
@@ -308,7 +308,7 @@ func (diagram Diagram) BoundingBox() (topLeft, bottomRight Point) {
 		}
 
 		if targetShape.Label != "" {
-			labelPosition := label.Position(targetShape.LabelPosition)
+			labelPosition := label.FromString(targetShape.LabelPosition)
 			if !labelPosition.IsOutside() {
 				continue
 			}
@@ -637,7 +637,7 @@ func (c Connection) CSSStyle() string {
 }
 
 func (c *Connection) GetLabelTopLeft() *geo.Point {
-	point, _ := label.Position(c.LabelPosition).GetPointOnRoute(
+	point, _ := label.FromString(c.LabelPosition).GetPointOnRoute(
 		c.Route,
 		float64(c.StrokeWidth),
 		c.LabelPercentage,
@@ -968,7 +968,7 @@ func init() {
 }
 
 func GetIconSize(box *geo.Box, position string) int {
-	iconPosition := label.Position(position)
+	iconPosition := label.FromString(position)
 
 	minDimension := int(math.Min(box.Width, box.Height))
 	halfMinDimension := int(math.Ceil(0.5 * float64(minDimension)))

--- a/lib/label/label.go
+++ b/lib/label/label.go
@@ -14,41 +14,168 @@ const RIGHT_LABEL_POSITION = 3.0 / 4.0
 // This is the space between a node border and its outside label
 const PADDING = 5
 
-type Position string
+type Position int8
 
 const (
-	OutsideTopLeft   Position = "OUTSIDE_TOP_LEFT"
-	OutsideTopCenter Position = "OUTSIDE_TOP_CENTER"
-	OutsideTopRight  Position = "OUTSIDE_TOP_RIGHT"
+	Unset Position = iota
 
-	OutsideLeftTop    Position = "OUTSIDE_LEFT_TOP"
-	OutsideLeftMiddle Position = "OUTSIDE_LEFT_MIDDLE"
-	OutsideLeftBottom Position = "OUTSIDE_LEFT_BOTTOM"
+	OutsideTopLeft
+	OutsideTopCenter
+	OutsideTopRight
 
-	OutsideRightTop    Position = "OUTSIDE_RIGHT_TOP"
-	OutsideRightMiddle Position = "OUTSIDE_RIGHT_MIDDLE"
-	OutsideRightBottom Position = "OUTSIDE_RIGHT_BOTTOM"
+	OutsideLeftTop
+	OutsideLeftMiddle
+	OutsideLeftBottom
 
-	OutsideBottomLeft   Position = "OUTSIDE_BOTTOM_LEFT"
-	OutsideBottomCenter Position = "OUTSIDE_BOTTOM_CENTER"
-	OutsideBottomRight  Position = "OUTSIDE_BOTTOM_RIGHT"
+	OutsideRightTop
+	OutsideRightMiddle
+	OutsideRightBottom
 
-	InsideTopLeft   Position = "INSIDE_TOP_LEFT"
-	InsideTopCenter Position = "INSIDE_TOP_CENTER"
-	InsideTopRight  Position = "INSIDE_TOP_RIGHT"
+	OutsideBottomLeft
+	OutsideBottomCenter
+	OutsideBottomRight
 
-	InsideMiddleLeft   Position = "INSIDE_MIDDLE_LEFT"
-	InsideMiddleCenter Position = "INSIDE_MIDDLE_CENTER"
-	InsideMiddleRight  Position = "INSIDE_MIDDLE_RIGHT"
+	InsideTopLeft
+	InsideTopCenter
+	InsideTopRight
 
-	InsideBottomLeft   Position = "INSIDE_BOTTOM_LEFT"
-	InsideBottomCenter Position = "INSIDE_BOTTOM_CENTER"
-	InsideBottomRight  Position = "INSIDE_BOTTOM_RIGHT"
+	InsideMiddleLeft
+	InsideMiddleCenter
+	InsideMiddleRight
 
-	UnlockedTop    Position = "UNLOCKED_TOP"
-	UnlockedMiddle Position = "UNLOCKED_MIDDLE"
-	UnlockedBottom Position = "UNLOCKED_BOTTOM"
+	InsideBottomLeft
+	InsideBottomCenter
+	InsideBottomRight
+
+	UnlockedTop
+	UnlockedMiddle
+	UnlockedBottom
 )
+
+func FromString(s string) Position {
+	switch s {
+	case "OUTSIDE_TOP_LEFT":
+		return OutsideTopLeft
+	case "OUTSIDE_TOP_CENTER":
+		return OutsideTopCenter
+	case "OUTSIDE_TOP_RIGHT":
+		return OutsideTopRight
+
+	case "OUTSIDE_LEFT_TOP":
+		return OutsideLeftTop
+	case "OUTSIDE_LEFT_MIDDLE":
+		return OutsideLeftMiddle
+	case "OUTSIDE_LEFT_BOTTOM":
+		return OutsideLeftBottom
+
+	case "OUTSIDE_RIGHT_TOP":
+		return OutsideRightTop
+	case "OUTSIDE_RIGHT_MIDDLE":
+		return OutsideRightMiddle
+	case "OUTSIDE_RIGHT_BOTTOM":
+		return OutsideRightBottom
+
+	case "OUTSIDE_BOTTOM_LEFT":
+		return OutsideBottomLeft
+	case "OUTSIDE_BOTTOM_CENTER":
+		return OutsideBottomCenter
+	case "OUTSIDE_BOTTOM_RIGHT":
+		return OutsideBottomRight
+
+	case "INSIDE_TOP_LEFT":
+		return InsideTopLeft
+	case "INSIDE_TOP_CENTER":
+		return InsideTopCenter
+	case "INSIDE_TOP_RIGHT":
+		return InsideTopRight
+
+	case "INSIDE_MIDDLE_LEFT":
+		return InsideMiddleLeft
+	case "INSIDE_MIDDLE_CENTER":
+		return InsideMiddleCenter
+	case "INSIDE_MIDDLE_RIGHT":
+		return InsideMiddleRight
+
+	case "INSIDE_BOTTOM_LEFT":
+		return InsideBottomLeft
+	case "INSIDE_BOTTOM_CENTER":
+		return InsideBottomCenter
+	case "INSIDE_BOTTOM_RIGHT":
+		return InsideBottomRight
+
+	case "UNLOCKED_TOP":
+		return UnlockedTop
+	case "UNLOCKED_MIDDLE":
+		return UnlockedMiddle
+	case "UNLOCKED_BOTTOM":
+		return UnlockedBottom
+	default:
+		return Unset
+	}
+}
+
+func (position Position) String() string {
+	switch position {
+	case OutsideTopLeft:
+		return "OUTSIDE_TOP_LEFT"
+	case OutsideTopCenter:
+		return "OUTSIDE_TOP_CENTER"
+	case OutsideTopRight:
+		return "OUTSIDE_TOP_RIGHT"
+
+	case OutsideLeftTop:
+		return "OUTSIDE_LEFT_TOP"
+	case OutsideLeftMiddle:
+		return "OUTSIDE_LEFT_MIDDLE"
+	case OutsideLeftBottom:
+		return "OUTSIDE_LEFT_BOTTOM"
+
+	case OutsideRightTop:
+		return "OUTSIDE_RIGHT_TOP"
+	case OutsideRightMiddle:
+		return "OUTSIDE_RIGHT_MIDDLE"
+	case OutsideRightBottom:
+		return "OUTSIDE_RIGHT_BOTTOM"
+
+	case OutsideBottomLeft:
+		return "OUTSIDE_BOTTOM_LEFT"
+	case OutsideBottomCenter:
+		return "OUTSIDE_BOTTOM_CENTER"
+	case OutsideBottomRight:
+		return "OUTSIDE_BOTTOM_RIGHT"
+
+	case InsideTopLeft:
+		return "INSIDE_TOP_LEFT"
+	case InsideTopCenter:
+		return "INSIDE_TOP_CENTER"
+	case InsideTopRight:
+		return "INSIDE_TOP_RIGHT"
+
+	case InsideMiddleLeft:
+		return "INSIDE_MIDDLE_LEFT"
+	case InsideMiddleCenter:
+		return "INSIDE_MIDDLE_CENTER"
+	case InsideMiddleRight:
+		return "INSIDE_MIDDLE_RIGHT"
+
+	case InsideBottomLeft:
+		return "INSIDE_BOTTOM_LEFT"
+	case InsideBottomCenter:
+		return "INSIDE_BOTTOM_CENTER"
+	case InsideBottomRight:
+		return "INSIDE_BOTTOM_RIGHT"
+
+	case UnlockedTop:
+		return "UNLOCKED_TOP"
+	case UnlockedMiddle:
+		return "UNLOCKED_MIDDLE"
+	case UnlockedBottom:
+		return "UNLOCKED_BOTTOM"
+
+	default:
+		return ""
+	}
+}
 
 func (position Position) IsShapePosition() bool {
 	switch position {
@@ -167,7 +294,7 @@ func (position Position) Mirrored() Position {
 		return UnlockedMiddle
 
 	default:
-		return ""
+		return Unset
 	}
 }
 


### PR DESCRIPTION

## Summary

Avoid working with label positions in memory as strings to avoid slow string comparisons.

## Details
- convert label.Position type to use int8
- `FromString(string) Position` and `String() string` for conversions