### PR TITLE
d2ir: Fix variables to passthrough primary type

### DIFF
--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -203,8 +203,12 @@ func (c *compiler) resolveSubstitutions(varsStack []*Map, node Node) {
 						n.Primary_ = nil
 					}
 				} else {
-					s.Value[i].String = go2.Pointer(resolvedField.Primary().Value.ScalarString())
-					subbed = true
+					if i == 0 && len(s.Value) == 1 {
+						node.Primary().Value = resolvedField.Primary().Value
+					} else {
+						s.Value[i].String = go2.Pointer(resolvedField.Primary().Value.ScalarString())
+						subbed = true
+					}
 				}
 				if resolvedField.Composite != nil {
 					switch n := node.(type) {

--- a/d2ir/import_test.go
+++ b/d2ir/import_test.go
@@ -157,7 +157,7 @@ label: meow`,
 					"a.d2":     "vars: { x: 2 }; hi: ${x}",
 				})
 				assert.Success(t, err)
-				assertQuery(t, m, 0, 0, "2", "hi")
+				assertQuery(t, m, 0, 0, 2, "hi")
 			},
 		},
 		{
@@ -168,7 +168,7 @@ label: meow`,
 					"a.d2":     "vars: { x: 2 }",
 				})
 				assert.Success(t, err)
-				assertQuery(t, m, 0, 0, "1", "hi")
+				assertQuery(t, m, 0, 0, 1, "hi")
 			},
 		},
 	}

--- a/testdata/d2compiler/TestCompile2/vars/basic/edge-label.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/edge-label.exp.json
@@ -115,7 +115,23 @@
                 "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/edge-label.d2,4:8:33-4:9:34",
                 "value": [
                   {
-                    "string": "im a var"
+                    "substitution": {
+                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/edge-label.d2,4:8:33-4:12:37",
+                      "spread": false,
+                      "path": [
+                        {
+                          "unquoted_string": {
+                            "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/edge-label.d2,4:10:35-4:11:36",
+                            "value": [
+                              {
+                                "string": "x",
+                                "raw_string": "x"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
                   }
                 ]
               }

--- a/testdata/d2compiler/TestCompile2/vars/basic/edge-map.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/edge-map.exp.json
@@ -150,7 +150,23 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/edge-map.d2,5:26:61-5:27:62",
                           "value": [
                             {
-                              "string": "im a var"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/edge-map.d2,5:26:61-5:30:65",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/edge-map.d2,5:28:63-5:29:64",
+                                      "value": [
+                                        {
+                                          "string": "x",
+                                          "raw_string": "x"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2compiler/TestCompile2/vars/basic/nested.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/nested.exp.json
@@ -185,7 +185,45 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/nested.d2,9:14:85-9:15:86",
                           "value": [
                             {
-                              "string": "red"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/nested.d2,9:14:85-9:38:109",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/nested.d2,9:16:87-9:22:93",
+                                      "value": [
+                                        {
+                                          "string": "colors",
+                                          "raw_string": "colors"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/nested.d2,9:23:94-9:30:101",
+                                      "value": [
+                                        {
+                                          "string": "primary",
+                                          "raw_string": "primary"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/nested.d2,9:31:102-9:37:108",
+                                      "value": [
+                                        {
+                                          "string": "button",
+                                          "raw_string": "button"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2compiler/TestCompile2/vars/basic/number.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/number.exp.json
@@ -112,7 +112,23 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/number.d2,5:15:44-5:16:45",
                           "value": [
                             {
-                              "string": "2"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/number.d2,5:15:44-5:25:54",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/number.d2,5:17:46-5:24:53",
+                                      "value": [
+                                        {
+                                          "string": "columns",
+                                          "raw_string": "columns"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2compiler/TestCompile2/vars/basic/parent-scope.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/parent-scope.exp.json
@@ -178,7 +178,23 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/parent-scope.d2,8:6:74-8:7:75",
                           "value": [
                             {
-                              "string": "im root var"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/parent-scope.d2,8:6:74-8:10:78",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/parent-scope.d2,8:8:76-8:9:77",
+                                      "value": [
+                                        {
+                                          "string": "x",
+                                          "raw_string": "x"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2compiler/TestCompile2/vars/basic/primary-and-composite.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/primary-and-composite.exp.json
@@ -131,7 +131,23 @@
                 "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/primary-and-composite.d2,6:3:35-6:4:36",
                 "value": [
                   {
-                    "string": "all"
+                    "substitution": {
+                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/primary-and-composite.d2,6:3:35-6:7:39",
+                      "spread": false,
+                      "path": [
+                        {
+                          "unquoted_string": {
+                            "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/primary-and-composite.d2,6:5:37-6:6:38",
+                            "value": [
+                              {
+                                "string": "x",
+                                "raw_string": "x"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
                   }
                 ]
               }

--- a/testdata/d2compiler/TestCompile2/vars/basic/quoted-var.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/quoted-var.exp.json
@@ -227,7 +227,45 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/quoted-var.d2,12:10:131-12:11:132",
                                     "value": [
                                       {
-                                        "string": "#4baae5"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/quoted-var.d2,12:10:131-12:40:161",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/quoted-var.d2,12:12:133-12:25:146",
+                                                "value": [
+                                                  {
+                                                    "string": "primaryColors",
+                                                    "raw_string": "primaryColors"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/quoted-var.d2,12:26:147-12:32:153",
+                                                "value": [
+                                                  {
+                                                    "string": "button",
+                                                    "raw_string": "button"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/quoted-var.d2,12:33:154-12:39:160",
+                                                "value": [
+                                                  {
+                                                    "string": "active",
+                                                    "raw_string": "active"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }

--- a/testdata/d2compiler/TestCompile2/vars/basic/shape-label.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/shape-label.exp.json
@@ -92,7 +92,23 @@
                 "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/shape-label.d2,4:4:29-4:5:30",
                 "value": [
                   {
-                    "string": "im a var"
+                    "substitution": {
+                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/shape-label.d2,4:4:29-4:8:33",
+                      "spread": false,
+                      "path": [
+                        {
+                          "unquoted_string": {
+                            "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/shape-label.d2,4:6:31-4:7:32",
+                            "value": [
+                              {
+                                "string": "x",
+                                "raw_string": "x"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
                   }
                 ]
               }

--- a/testdata/d2compiler/TestCompile2/vars/basic/style.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/style.exp.json
@@ -127,7 +127,23 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/style.d2,5:14:52-5:15:53",
                           "value": [
                             {
-                              "string": "red"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/style.d2,5:14:52-5:30:68",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/style.d2,5:16:54-5:29:67",
+                                      "value": [
+                                        {
+                                          "string": "primary-color",
+                                          "raw_string": "primary-color"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2compiler/TestCompile2/vars/basic/sub-array.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/basic/sub-array.exp.json
@@ -118,7 +118,23 @@
                       "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/sub-array.d2,4:13:32-4:14:33",
                       "value": [
                         {
-                          "string": "all"
+                          "substitution": {
+                            "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/sub-array.d2,4:13:32-4:17:36",
+                            "spread": false,
+                            "path": [
+                              {
+                                "unquoted_string": {
+                                  "range": "d2/testdata/d2compiler/TestCompile2/vars/basic/sub-array.d2,4:15:34-4:16:35",
+                                  "value": [
+                                    {
+                                      "string": "x",
+                                      "raw_string": "x"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
                         }
                       ]
                     }

--- a/testdata/d2compiler/TestCompile2/vars/boards/layer-2.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/boards/layer-2.exp.json
@@ -235,7 +235,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,11:8:108-11:9:109",
                                     "value": [
                                       {
-                                        "string": "layer var x"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,11:8:108-11:12:112",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,11:10:110-11:11:111",
+                                                "value": [
+                                                  {
+                                                    "string": "x",
+                                                    "raw_string": "x"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -267,7 +283,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,12:11:124-12:12:125",
                                     "value": [
                                       {
-                                        "string": "root var y"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,12:11:124-12:15:128",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,12:13:126-12:14:127",
+                                                "value": [
+                                                  {
+                                                    "string": "y",
+                                                    "raw_string": "y"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -398,10 +430,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,11:8:108-11:9:109",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,9:9:82-9:20:93",
                     "value": [
                       {
-                        "string": "layer var x"
+                        "string": "layer var x",
+                        "raw_string": "layer var x"
                       }
                     ]
                   }
@@ -429,10 +462,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,12:11:124-12:12:125",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer-2.d2,3:5:30-3:15:40",
                     "value": [
                       {
-                        "string": "root var y"
+                        "string": "root var y",
+                        "raw_string": "root var y"
                       }
                     ]
                   }

--- a/testdata/d2compiler/TestCompile2/vars/boards/layer.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/boards/layer.exp.json
@@ -140,7 +140,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer.d2,7:8:51-7:9:52",
                                     "value": [
                                       {
-                                        "string": "im a var"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer.d2,7:8:51-7:12:55",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer.d2,7:10:53-7:11:54",
+                                                "value": [
+                                                  {
+                                                    "string": "x",
+                                                    "raw_string": "x"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -211,10 +227,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer.d2,7:8:51-7:9:52",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/layer.d2,2:5:14-2:13:22",
                     "value": [
                       {
-                        "string": "im a var"
+                        "string": "im a var",
+                        "raw_string": "im a var"
                       }
                     ]
                   }

--- a/testdata/d2compiler/TestCompile2/vars/boards/overlay.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/boards/overlay.exp.json
@@ -202,7 +202,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,10:7:89-10:8:90",
                                     "value": [
                                       {
-                                        "string": "im x var"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,10:7:89-10:11:93",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,10:9:91-10:10:92",
+                                                "value": [
+                                                  {
+                                                    "string": "x",
+                                                    "raw_string": "x"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -234,7 +250,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,11:7:101-11:8:102",
                                     "value": [
                                       {
-                                        "string": "im y var"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,11:7:101-11:11:105",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,11:9:103-11:10:104",
+                                                "value": [
+                                                  {
+                                                    "string": "y",
+                                                    "raw_string": "y"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -386,7 +418,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,19:7:173-19:8:174",
                                     "value": [
                                       {
-                                        "string": "im x var"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,19:7:173-19:11:177",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,19:9:175-19:10:176",
+                                                "value": [
+                                                  {
+                                                    "string": "x",
+                                                    "raw_string": "x"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -418,7 +466,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,20:7:185-20:8:186",
                                     "value": [
                                       {
-                                        "string": "im y var"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,20:7:185-20:11:189",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,20:9:187-20:10:188",
+                                                "value": [
+                                                  {
+                                                    "string": "y",
+                                                    "raw_string": "y"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -549,10 +613,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,19:7:173-19:8:174",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,2:5:14-2:13:22",
                     "value": [
                       {
-                        "string": "im x var"
+                        "string": "im x var",
+                        "raw_string": "im x var"
                       }
                     ]
                   }
@@ -580,10 +645,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,20:7:185-20:8:186",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,17:9:151-17:17:159",
                     "value": [
                       {
-                        "string": "im y var"
+                        "string": "im y var",
+                        "raw_string": "im y var"
                       }
                     ]
                   }
@@ -830,10 +896,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,10:7:89-10:8:90",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,2:5:14-2:13:22",
                     "value": [
                       {
-                        "string": "im x var"
+                        "string": "im x var",
+                        "raw_string": "im x var"
                       }
                     ]
                   }
@@ -861,10 +928,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,11:7:101-11:8:102",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/overlay.d2,8:9:67-8:17:75",
                     "value": [
                       {
-                        "string": "im y var"
+                        "string": "im y var",
+                        "raw_string": "im y var"
                       }
                     ]
                   }

--- a/testdata/d2compiler/TestCompile2/vars/boards/replace.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/boards/replace.exp.json
@@ -202,7 +202,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/replace.d2,10:7:98-10:8:99",
                                     "value": [
                                       {
-                                        "string": "im replaced x var"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/replace.d2,10:7:98-10:11:102",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/replace.d2,10:9:100-10:10:101",
+                                                "value": [
+                                                  {
+                                                    "string": "x",
+                                                    "raw_string": "x"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -333,10 +349,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/replace.d2,10:7:98-10:8:99",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/replace.d2,8:9:67-8:26:84",
                     "value": [
                       {
-                        "string": "im replaced x var"
+                        "string": "im replaced x var",
+                        "raw_string": "im replaced x var"
                       }
                     ]
                   }

--- a/testdata/d2compiler/TestCompile2/vars/boards/scenario.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/boards/scenario.exp.json
@@ -140,7 +140,23 @@
                                     "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/scenario.d2,7:8:54-7:9:55",
                                     "value": [
                                       {
-                                        "string": "im a var"
+                                        "substitution": {
+                                          "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/scenario.d2,7:8:54-7:12:58",
+                                          "spread": false,
+                                          "path": [
+                                            {
+                                              "unquoted_string": {
+                                                "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/scenario.d2,7:10:56-7:11:57",
+                                                "value": [
+                                                  {
+                                                    "string": "x",
+                                                    "raw_string": "x"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     ]
                                   }
@@ -271,10 +287,11 @@
                 },
                 "primary": {
                   "unquoted_string": {
-                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/scenario.d2,7:8:54-7:9:55",
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/boards/scenario.d2,2:5:14-2:13:22",
                     "value": [
                       {
-                        "string": "im a var"
+                        "string": "im a var",
+                        "raw_string": "im a var"
                       }
                     ]
                   }

--- a/testdata/d2compiler/TestCompile2/vars/override/map.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/override/map.exp.json
@@ -178,7 +178,23 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/override/map.d2,8:6:74-8:7:75",
                           "value": [
                             {
-                              "string": "im nested var"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/override/map.d2,8:6:74-8:10:78",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/override/map.d2,8:8:76-8:9:77",
+                                      "value": [
+                                        {
+                                          "string": "x",
+                                          "raw_string": "x"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2compiler/TestCompile2/vars/override/recursive-var.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/override/recursive-var.exp.json
@@ -177,7 +177,23 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/override/recursive-var.d2,8:6:58-8:7:59",
                           "value": [
                             {
-                              "string": "a-b"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/override/recursive-var.d2,8:6:58-8:10:62",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/override/recursive-var.d2,8:8:60-8:9:61",
+                                      "value": [
+                                        {
+                                          "string": "x",
+                                          "raw_string": "x"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2compiler/TestCompile2/vars/override/var-in-var.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/override/var-in-var.exp.json
@@ -209,7 +209,23 @@
                           "range": "d2/testdata/d2compiler/TestCompile2/vars/override/var-in-var.d2,9:6:104-9:7:105",
                           "value": [
                             {
-                              "string": "BlackSmith"
+                              "substitution": {
+                                "range": "d2/testdata/d2compiler/TestCompile2/vars/override/var-in-var.d2,9:6:104-9:15:113",
+                                "spread": false,
+                                "path": [
+                                  {
+                                    "unquoted_string": {
+                                      "range": "d2/testdata/d2compiler/TestCompile2/vars/override/var-in-var.d2,9:8:106-9:14:112",
+                                      "value": [
+                                        {
+                                          "string": "trade1",
+                                          "raw_string": "trade1"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/testdata/d2ir/TestCompile/imports/vars/1.exp.json
+++ b/testdata/d2ir/TestCompile/imports/vars/1.exp.json
@@ -168,10 +168,11 @@
       "name": "q",
       "primary": {
         "value": {
-          "range": "index.d2,0:20:20-0:21:21",
+          "range": "x.d2,0:6:6-0:18:18",
           "value": [
             {
-              "string": "var replaced"
+              "string": "var replaced",
+              "raw_string": "var replaced"
             }
           ]
         }
@@ -229,7 +230,23 @@
                   "range": "index.d2,0:20:20-0:21:21",
                   "value": [
                     {
-                      "string": "var replaced"
+                      "substitution": {
+                        "range": "index.d2,0:20:20-0:27:27",
+                        "spread": false,
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "index.d2,0:22:22-0:26:26",
+                              "value": [
+                                {
+                                  "string": "meow",
+                                  "raw_string": "meow"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
                     }
                   ]
                 }

--- a/testdata/d2ir/TestCompile/imports/vars/2.exp.json
+++ b/testdata/d2ir/TestCompile/imports/vars/2.exp.json
@@ -312,12 +312,9 @@
       "name": "hi",
       "primary": {
         "value": {
-          "range": "a.d2,0:20:20-0:21:21",
-          "value": [
-            {
-              "string": "2"
-            }
-          ]
+          "range": "a.d2,0:11:11-0:12:12",
+          "raw": "2",
+          "value": "2"
         }
       },
       "references": [
@@ -373,7 +370,23 @@
                   "range": "a.d2,0:20:20-0:21:21",
                   "value": [
                     {
-                      "string": "2"
+                      "substitution": {
+                        "range": "a.d2,0:20:20-0:24:24",
+                        "spread": false,
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "a.d2,0:22:22-0:23:23",
+                              "value": [
+                                {
+                                  "string": "x",
+                                  "raw_string": "x"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
                     }
                   ]
                 }

--- a/testdata/d2ir/TestCompile/imports/vars/3.exp.json
+++ b/testdata/d2ir/TestCompile/imports/vars/3.exp.json
@@ -312,12 +312,9 @@
       "name": "hi",
       "primary": {
         "value": {
-          "range": "index.d2,0:27:27-0:28:28",
-          "value": [
-            {
-              "string": "1"
-            }
-          ]
+          "range": "index.d2,0:18:18-0:19:19",
+          "raw": "1",
+          "value": "1"
         }
       },
       "references": [
@@ -373,7 +370,23 @@
                   "range": "index.d2,0:27:27-0:28:28",
                   "value": [
                     {
-                      "string": "1"
+                      "substitution": {
+                        "range": "index.d2,0:27:27-0:31:31",
+                        "spread": false,
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "index.d2,0:29:29-0:30:30",
+                              "value": [
+                                {
+                                  "string": "x",
+                                  "raw_string": "x"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
                     }
                   ]
                 }


### PR DESCRIPTION
If the variable is a number it should be parsed as a number and not coerced into a string. See test change.

<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
