### PR TITLE
layers support in watch mode

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -8,6 +8,7 @@ Layout capability also takes a subtle but important step forward: you can now cu
 - Configure timeout value with D2_TIMEOUT env var [#1392](https://github.com/terrastruct/d2/pull/1392)
 - Scale renders and disable fit to screen with `--scale` flag [#1413](https://github.com/terrastruct/d2/pull/1413)
 - `null` keyword can be used to un-declare. See [docs](https://d2lang.com/tour/overrides#null) [#1446](https://github.com/terrastruct/d2/pull/1446)
+- Develop multi-board diagrams in watch mode (links to layers/scenarios/steps work in `--watch`) [#1503](https://github.com/terrastruct/d2/pull/1503)
 
 #### Improvements 🧹
 

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -331,7 +331,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	ctx, cancel := timelib.WithTimeout(ctx, time.Minute*2)
 	defer cancel()
 
-	_, written, err := compile(ctx, ms, plugins, layoutFlag, renderOpts, fontFamily, *animateIntervalFlag, inputPath, outputPath, *bundleFlag, *forceAppendixFlag, pw.Page)
+	_, written, err := compile(ctx, ms, plugins, layoutFlag, renderOpts, fontFamily, *animateIntervalFlag, inputPath, outputPath, "", *bundleFlag, *forceAppendixFlag, pw.Page)
 	if err != nil {
 		if written {
 			return fmt.Errorf("failed to fully compile (partial render written): %w", err)
@@ -366,7 +366,7 @@ func LayoutResolver(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plu
 	}
 }
 
-func compile(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin, layout *string, renderOpts d2svg.RenderOpts, fontFamily *d2fonts.FontFamily, animateInterval int64, inputPath, outputPath string, bundle, forceAppendix bool, page playwright.Page) (_ []byte, written bool, _ error) {
+func compile(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin, layout *string, renderOpts d2svg.RenderOpts, fontFamily *d2fonts.FontFamily, animateInterval int64, inputPath, outputPath, boardPath string, bundle, forceAppendix bool, page playwright.Page) (_ []byte, written bool, _ error) {
 	start := time.Now()
 	input, err := ms.ReadPath(inputPath)
 	if err != nil {
@@ -500,7 +500,12 @@ func compile(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin, la
 			}
 		}
 
-		boards, err := render(ctx, ms, compileDur, plugin, renderOpts, inputPath, outputPath, bundle, forceAppendix, page, ruler, diagram)
+		board := diagram.GetBoard(boardPath)
+		if board == nil {
+			return nil, false, fmt.Errorf("Diagram with path %s not found", boardPath)
+		}
+
+		boards, err := render(ctx, ms, compileDur, plugin, renderOpts, inputPath, outputPath, bundle, forceAppendix, page, ruler, board)
 		if err != nil {
 			return nil, false, err
 		}

--- a/d2cli/static/watch.js
+++ b/d2cli/static/watch.js
@@ -9,7 +9,7 @@ function init(reconnectDelay) {
 
   const devMode = document.body.dataset.d2DevMode === "true";
   const ws = new WebSocket(
-    `ws://${window.location.host}${window.location.pathname}watch`
+    `ws://${window.location.host}/watch`
   );
   let isInit = true;
   let ratio;
@@ -28,7 +28,7 @@ function init(reconnectDelay) {
       // we can't just set `d2SVG.innerHTML = msg.svg` need to parse this as xml not html
       const parsedXML = new DOMParser().parseFromString(msg.svg, "text/xml");
       d2SVG.replaceChildren(parsedXML.documentElement);
-      changeFavicon("./static/favicon.ico");
+      changeFavicon("/static/favicon.ico");
       const svgEl = d2SVG.querySelector("#d2-svg");
       // just use inner SVG in watch mode
       svgEl.parentElement.replaceWith(svgEl);
@@ -60,7 +60,7 @@ function init(reconnectDelay) {
     if (msg.err) {
       d2ErrDiv.innerText = msg.err;
       d2ErrDiv.style.display = "block";
-      changeFavicon("./static/favicon-err.ico");
+      changeFavicon("/static/favicon-err.ico");
       d2ErrDiv.scrollIntoView();
     }
   };

--- a/d2cli/static/watch.js
+++ b/d2cli/static/watch.js
@@ -8,9 +8,7 @@ function init(reconnectDelay) {
   const d2SVG = window.document.querySelector("#d2-svg-container");
 
   const devMode = document.body.dataset.d2DevMode === "true";
-  const ws = new WebSocket(
-    `ws://${window.location.host}/watch`
-  );
+  const ws = new WebSocket(`ws://${window.location.host}/watch`);
   let isInit = true;
   let ratio;
   ws.onopen = () => {

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -443,8 +443,10 @@ func (w *watcher) handleRoot(hw http.ResponseWriter, r *http.Request) {
 </html>`, filepath.Base(w.outputPath), w.devMode)
 
 	// if path is "/x.svg", we just want "x"
-	split := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), ".")
-	boardPath := strings.Join(split[:len(split)-1], ".")
+	boardPath := strings.TrimPrefix(r.URL.Path, "/")
+	if idx := strings.LastIndexByte(boardPath, '.'); idx != -1 {
+		boardPath = boardPath[:idx]
+	}
 	if boardPath != w.boardPath {
 		w.boardPath = boardPath
 		w.requestCompile()

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -81,53 +81,59 @@ func (d *Diagram) GetBoard(boardPath string) *Diagram {
 		return d
 	}
 
-	head := path[0]
+	return d.getBoard(path)
+}
+
+func (d *Diagram) getBoard(boardPath []string) *Diagram {
+	head := boardPath[0]
 
 	if head == "index" {
 		return d
 	}
 
 	switch head {
-	case "layers", "scenarios", "steps":
-		if len(path) < 2 {
+	case "layers":
+		if len(boardPath) < 2 {
 			return nil
 		}
-	}
-
-	switch head {
-	case "layers":
 		for _, b := range d.Layers {
-			if b.Name == path[1] {
-				return b.GetBoard(strings.Join(path[2:], string(os.PathSeparator)))
+			if b.Name == boardPath[1] {
+				return b.getBoard(boardPath[2:])
 			}
 		}
 	case "scenarios":
+		if len(boardPath) < 2 {
+			return nil
+		}
 		for _, b := range d.Scenarios {
-			if b.Name == path[1] {
-				return b.GetBoard(strings.Join(path[2:], string(os.PathSeparator)))
+			if b.Name == boardPath[1] {
+				return b.getBoard(boardPath[2:])
 			}
 		}
 	case "steps":
+		if len(boardPath) < 2 {
+			return nil
+		}
 		for _, b := range d.Steps {
-			if b.Name == path[1] {
-				return b.GetBoard(strings.Join(path[2:], string(os.PathSeparator)))
+			if b.Name == boardPath[1] {
+				return b.getBoard(boardPath[2:])
 			}
 		}
 	}
 
 	for _, b := range d.Layers {
 		if b.Name == head {
-			return b.GetBoard(strings.Join(path[1:], string(os.PathSeparator)))
+			return b.getBoard(boardPath[2:])
 		}
 	}
 	for _, b := range d.Scenarios {
 		if b.Name == head {
-			return b.GetBoard(strings.Join(path[1:], string(os.PathSeparator)))
+			return b.getBoard(boardPath[2:])
 		}
 	}
 	for _, b := range d.Steps {
 		if b.Name == head {
-			return b.GetBoard(strings.Join(path[1:], string(os.PathSeparator)))
+			return b.getBoard(boardPath[2:])
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

Let users develop multi-board diagrams in watch mode.

Example of clicking links to navigate in watch mode:

https://github.com/terrastruct/d2/assets/3120367/5dfb4e99-919b-4b6a-8ff1-7ffdd4d43738

The back button doesn't work to update the board, at least on mac. I guess it doesn't trigger a page refresh for some reason, but this can be deferred.

closes #1176