### PR TITLE
fix(cli): do not exit after 1st formatted file

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -5,3 +5,5 @@
 #### Improvements 🧹
 
 #### Bugfixes ⛑️
+
+- Fixes `d2 fmt` to format all files passed as arguments rather than first non-formatted only [#1523](https://github.com/terrastruct/d2/issues/1523)

--- a/d2cli/fmt.go
+++ b/d2cli/fmt.go
@@ -43,7 +43,9 @@ func fmtCmd(ctx context.Context, ms *xmain.State) (err error) {
 
 		output := []byte(d2format.Format(m))
 		if !bytes.Equal(output, input) {
-			return ms.WritePath(inputPath, output)
+			if err := ms.WritePath(inputPath, output); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -531,6 +531,19 @@ i used to read
 				assert.Equal(t, "x -> y\n", string(got))
 			},
 		},
+		{
+			name: "fmt-multiple-files",
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "foo.d2", `a ---> b`)
+				writeFile(t, dir, "bar.d2", `x ---> y`)
+				err := runTestMainPersist(t, ctx, dir, env, "fmt", "foo.d2", "bar.d2")
+				assert.Success(t, err)
+				gotFoo := readFile(t, dir, "foo.d2")
+				gotBar := readFile(t, dir, "bar.d2")
+				assert.Equal(t, "a -> b\n", string(gotFoo))
+				assert.Equal(t, "x -> y\n", string(gotBar))
+			},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

Hello! 👋

Thank you so much for `d2`, loving it so far!

Found a small bug in `d2 fmt`: If ran on multiple non-formatted files at once, it would format the 1st and exit, leaving the others non-formatted.