### PR TITLE
feat: add d2-fmt pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: d2-fmt
+  name: d2 fmt
+  description: Format d2 files
+  entry: d2 fmt
+  language: golang
+  files: \.d2$


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

Add a [pre-commit](https://pre-commit.com/) hook for `d2 fmt`, usage:

```yaml
# .pre-commit-config.yaml
repos:
  - repo: https://github.com/terrastruct/d2
    rev: v0.7.0
    hooks:
      - id: d2-fmt
```

`pre-commit` will take care of cloning the repo, downloading `go` if needed, and building `d2`: [pre-commit.com/#golang](https://pre-commit.com/#golang)

Can be tested with:

```shell
pre-commit try-repo --all-files --ref=feat/fmt-pre-commit-hook https://github.com/maxbrunet/d2
```

_Note:_ It would be nice to have a `d2` hook to generate the diagrams, but `d2Version=` is included in the headers and requires the version `ldflag` to be set at build time which is not supported by `pre-commit`.