### PR TITLE
d2oracle: nulls at end

### DIFF
--- a/d2oracle/edit.go
+++ b/d2oracle/edit.go
@@ -807,11 +807,6 @@ func appendMapKey(m *d2ast.Map, mk *d2ast.Key) {
 	}
 }
 
-func prependMapKey(m *d2ast.Map, mk *d2ast.Key) {
-	appendMapKey(m, mk)
-	m.Nodes = append([]d2ast.MapNodeBox{m.Nodes[len(m.Nodes)-1]}, m.Nodes[:len(m.Nodes)-1]...)
-}
-
 func Delete(g *d2graph.Graph, boardPath []string, key string) (_ *d2graph.Graph, err error) {
 	defer xdefer.Errorf(&err, "failed to delete %#v", key)
 
@@ -900,7 +895,8 @@ func Delete(g *d2graph.Graph, boardPath []string, key string) (_ *d2graph.Graph,
 				}
 			}
 		} else {
-			prependMapKey(baseAST, mk)
+			// NOTE: it only needs to be after the last ref, but perhaps simplest and cleanest to append all nulls at the end
+			appendMapKey(baseAST, mk)
 		}
 		if len(boardPath) > 0 {
 			replaced := ReplaceBoardNode(g.AST, baseAST, boardPath)
@@ -941,7 +937,7 @@ func Delete(g *d2graph.Graph, boardPath []string, key string) (_ *d2graph.Graph,
 			return nil, err
 		}
 	} else {
-		prependMapKey(baseAST, mk)
+		appendMapKey(baseAST, mk)
 	}
 
 	if len(boardPath) > 0 {

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -7014,10 +7014,9 @@ scenarios: {
 
 scenarios: {
   x: {
-    a: null
-
     b
     c
+    a: null
   }
 }
 `,
@@ -7041,10 +7040,9 @@ scenarios: {
 
 scenarios: {
   x: {
-    (a -> b)[0]: null
-
     b
     c
+    (a -> b)[0]: null
   }
 }
 `,

--- a/testdata/d2oracle/TestDelete/scenarios-edge-inherited.exp.json
+++ b/testdata/d2oracle/TestDelete/scenarios-edge-inherited.exp.json
@@ -3,7 +3,7 @@
     "name": "",
     "isFolderOnly": false,
     "ast": {
-      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,0:0:0-10:0:69",
+      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,0:0:0-9:0:68",
       "nodes": [
         {
           "map_key": {
@@ -53,7 +53,7 @@
         },
         {
           "map_key": {
-            "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,2:0:8-9:1:68",
+            "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,2:0:8-8:1:67",
             "key": {
               "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,2:0:8-2:9:17",
               "path": [
@@ -73,11 +73,11 @@
             "primary": {},
             "value": {
               "map": {
-                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,2:11:19-9:1:68",
+                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,2:11:19-8:1:67",
                 "nodes": [
                   {
                     "map_key": {
-                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,3:2:23-8:3:66",
+                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,3:2:23-7:3:65",
                       "key": {
                         "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,3:2:23-3:3:24",
                         "path": [
@@ -97,72 +97,17 @@
                       "primary": {},
                       "value": {
                         "map": {
-                          "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,3:5:26-8:3:66",
+                          "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,3:5:26-7:3:65",
                           "nodes": [
                             {
                               "map_key": {
-                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:4:32-4:21:49",
-                                "edges": [
-                                  {
-                                    "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:5:33-4:11:39",
-                                    "src": {
-                                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:5:33-4:6:34",
-                                      "path": [
-                                        {
-                                          "unquoted_string": {
-                                            "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:5:33-4:6:34",
-                                            "value": [
-                                              {
-                                                "string": "a",
-                                                "raw_string": "a"
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "src_arrow": "",
-                                    "dst": {
-                                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:10:38-4:11:39",
-                                      "path": [
-                                        {
-                                          "unquoted_string": {
-                                            "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:10:38-4:11:39",
-                                            "value": [
-                                              {
-                                                "string": "b",
-                                                "raw_string": "b"
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "dst_arrow": ">"
-                                  }
-                                ],
-                                "edge_index": {
-                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:12:40-4:15:43",
-                                  "int": 0,
-                                  "glob": false
-                                },
-                                "primary": {},
-                                "value": {
-                                  "null": {
-                                    "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:17:45-4:21:49"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "map_key": {
-                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:4:55-6:5:56",
+                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:4:32-4:5:33",
                                 "key": {
-                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:4:55-6:5:56",
+                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:4:32-4:5:33",
                                   "path": [
                                     {
                                       "unquoted_string": {
-                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:4:55-6:5:56",
+                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:4:32-4:5:33",
                                         "value": [
                                           {
                                             "string": "b",
@@ -179,13 +124,13 @@
                             },
                             {
                               "map_key": {
-                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,7:4:61-7:5:62",
+                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,5:4:38-5:5:39",
                                 "key": {
-                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,7:4:61-7:5:62",
+                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,5:4:38-5:5:39",
                                   "path": [
                                     {
                                       "unquoted_string": {
-                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,7:4:61-7:5:62",
+                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,5:4:38-5:5:39",
                                         "value": [
                                           {
                                             "string": "c",
@@ -198,6 +143,61 @@
                                 },
                                 "primary": {},
                                 "value": {}
+                              }
+                            },
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:4:44-6:21:61",
+                                "edges": [
+                                  {
+                                    "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:5:45-6:11:51",
+                                    "src": {
+                                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:5:45-6:6:46",
+                                      "path": [
+                                        {
+                                          "unquoted_string": {
+                                            "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:5:45-6:6:46",
+                                            "value": [
+                                              {
+                                                "string": "a",
+                                                "raw_string": "a"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "src_arrow": "",
+                                    "dst": {
+                                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:10:50-6:11:51",
+                                      "path": [
+                                        {
+                                          "unquoted_string": {
+                                            "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:10:50-6:11:51",
+                                            "value": [
+                                              {
+                                                "string": "b",
+                                                "raw_string": "b"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dst_arrow": ">"
+                                  }
+                                ],
+                                "edge_index": {
+                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:12:52-6:15:55",
+                                  "int": 0,
+                                  "glob": false
+                                },
+                                "primary": {},
+                                "value": {
+                                  "null": {
+                                    "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:17:57-6:21:61"
+                                  }
+                                }
                               }
                             }
                           ]
@@ -530,11 +530,11 @@
               },
               {
                 "key": {
-                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:4:55-6:5:56",
+                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:4:32-4:5:33",
                   "path": [
                     {
                       "unquoted_string": {
-                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,6:4:55-6:5:56",
+                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,4:4:32-4:5:33",
                         "value": [
                           {
                             "string": "b",
@@ -575,11 +575,11 @@
             "references": [
               {
                 "key": {
-                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,7:4:61-7:5:62",
+                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,5:4:38-5:5:39",
                   "path": [
                     {
                       "unquoted_string": {
-                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,7:4:61-7:5:62",
+                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-edge-inherited.d2,5:4:38-5:5:39",
                         "value": [
                           {
                             "string": "c",

--- a/testdata/d2oracle/TestDelete/scenarios-inherited.exp.json
+++ b/testdata/d2oracle/TestDelete/scenarios-inherited.exp.json
@@ -3,7 +3,7 @@
     "name": "",
     "isFolderOnly": false,
     "ast": {
-      "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,0:0:0-10:0:54",
+      "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,0:0:0-9:0:53",
       "nodes": [
         {
           "map_key": {
@@ -30,7 +30,7 @@
         },
         {
           "map_key": {
-            "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,2:0:3-9:1:53",
+            "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,2:0:3-8:1:52",
             "key": {
               "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,2:0:3-2:9:12",
               "path": [
@@ -50,11 +50,11 @@
             "primary": {},
             "value": {
               "map": {
-                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,2:11:14-9:1:53",
+                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,2:11:14-8:1:52",
                 "nodes": [
                   {
                     "map_key": {
-                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,3:2:18-8:3:51",
+                      "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,3:2:18-7:3:50",
                       "key": {
                         "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,3:2:18-3:3:19",
                         "path": [
@@ -74,44 +74,17 @@
                       "primary": {},
                       "value": {
                         "map": {
-                          "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,3:5:21-8:3:51",
+                          "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,3:5:21-7:3:50",
                           "nodes": [
                             {
                               "map_key": {
-                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,4:4:27-4:11:34",
+                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,4:4:27-4:5:28",
                                 "key": {
                                   "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,4:4:27-4:5:28",
                                   "path": [
                                     {
                                       "unquoted_string": {
                                         "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,4:4:27-4:5:28",
-                                        "value": [
-                                          {
-                                            "string": "a",
-                                            "raw_string": "a"
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                },
-                                "primary": {},
-                                "value": {
-                                  "null": {
-                                    "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,4:7:30-4:11:34"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "map_key": {
-                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:40-6:5:41",
-                                "key": {
-                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:40-6:5:41",
-                                  "path": [
-                                    {
-                                      "unquoted_string": {
-                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:40-6:5:41",
                                         "value": [
                                           {
                                             "string": "b",
@@ -128,13 +101,13 @@
                             },
                             {
                               "map_key": {
-                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,7:4:46-7:5:47",
+                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,5:4:33-5:5:34",
                                 "key": {
-                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,7:4:46-7:5:47",
+                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,5:4:33-5:5:34",
                                   "path": [
                                     {
                                       "unquoted_string": {
-                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,7:4:46-7:5:47",
+                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,5:4:33-5:5:34",
                                         "value": [
                                           {
                                             "string": "c",
@@ -147,6 +120,33 @@
                                 },
                                 "primary": {},
                                 "value": {}
+                              }
+                            },
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:39-6:11:46",
+                                "key": {
+                                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:39-6:5:40",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:39-6:5:40",
+                                        "value": [
+                                          {
+                                            "string": "a",
+                                            "raw_string": "a"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "null": {
+                                    "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:7:42-6:11:46"
+                                  }
+                                }
                               }
                             }
                           ]
@@ -316,11 +316,11 @@
             "references": [
               {
                 "key": {
-                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:40-6:5:41",
+                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,4:4:27-4:5:28",
                   "path": [
                     {
                       "unquoted_string": {
-                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,6:4:40-6:5:41",
+                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,4:4:27-4:5:28",
                         "value": [
                           {
                             "string": "b",
@@ -361,11 +361,11 @@
             "references": [
               {
                 "key": {
-                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,7:4:46-7:5:47",
+                  "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,5:4:33-5:5:34",
                   "path": [
                     {
                       "unquoted_string": {
-                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,7:4:46-7:5:47",
+                        "range": "d2/testdata/d2oracle/TestDelete/scenarios-inherited.d2,5:4:33-5:5:34",
                         "value": [
                           {
                             "string": "c",


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

If the API is used to delete an object from a board, the nulling should go at the last line, not the first. The reason is that the board may use the object in its own DSL, and adding null at the start would do nothing.
