### PR TITLE
Fix UsageError typo for `--animate-interval`

### DIFF
--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -216,9 +216,9 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if outputPath != "-" {
 		outputPath = ms.AbsPath(outputPath)
 		if *animateIntervalFlag > 0 && !outputFormat.supportsAnimation() {
-			return xmain.UsageErrorf("-animate-interval can only be used when exporting to SVG or GIF.\nYou provided: %s", filepath.Ext(outputPath))
+			return xmain.UsageErrorf("--animate-interval can only be used when exporting to SVG or GIF.\nYou provided: %s", filepath.Ext(outputPath))
 		} else if *animateIntervalFlag <= 0 && outputFormat.requiresAnimationInterval() {
-			return xmain.UsageErrorf("-animate-interval must be greater than 0 for %s outputs.\nYou provided: %d", outputFormat, *animateIntervalFlag)
+			return xmain.UsageErrorf("--animate-interval must be greater than 0 for %s outputs.\nYou provided: %d", outputFormat, *animateIntervalFlag)
 		}
 	}
 


### PR DESCRIPTION
This pull request fixes a typo when displaying a `xmain.UsageErrorf`, the flag displayed says you need to specify `-animate-interval`, when it should be `--animate-interval`.