### PR TITLE
check for empty labels on text shape

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -13,3 +13,4 @@
 
 - Fixes `d2 fmt` to format all files passed as arguments rather than first non-formatted only [#1523](https://github.com/terrastruct/d2/issues/1523)
 - Fixes Markdown cropping last element in mixed-element blocks (e.g. em and strong) [#1543](https://github.com/terrastruct/d2/issues/1543)
+- Fixes missing compile error for non-blockstring empty labels [#1590](https://github.com/terrastruct/d2/issues/1590)

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -82,6 +82,7 @@ func (c *compiler) compileBoard(g *d2graph.Graph, ir *d2ir.Map) *d2graph.Graph {
 	if len(c.err.Errors) == 0 {
 		c.validateKeys(g.Root, ir)
 	}
+	c.validateLabels(g)
 	c.validateNear(g)
 	c.validateEdges(g)
 
@@ -995,6 +996,17 @@ func (c *compiler) validateKey(obj *d2graph.Object, f *d2ir.Field) {
 	obj, ok := obj.HasChild([]string{f.Name})
 	if ok && f.Map() != nil {
 		c.validateKeys(obj, f.Map())
+	}
+}
+
+func (c *compiler) validateLabels(g *d2graph.Graph) {
+	for _, obj := range g.Objects {
+		if obj.Shape.Value == d2target.ShapeText {
+			if strings.TrimSpace(obj.Label.Value) == "" {
+				c.errorf(obj.Label.MapKey, "text must have a label")
+				continue
+			}
+		}
 	}
 }
 

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -1001,11 +1001,16 @@ func (c *compiler) validateKey(obj *d2graph.Object, f *d2ir.Field) {
 
 func (c *compiler) validateLabels(g *d2graph.Graph) {
 	for _, obj := range g.Objects {
-		if obj.Shape.Value == d2target.ShapeText {
-			if strings.TrimSpace(obj.Label.Value) == "" {
-				c.errorf(obj.Label.MapKey, "text must have a label")
-				continue
-			}
+		if obj.Shape.Value != d2target.ShapeText {
+			continue
+		}
+		if obj.Attributes.Language != "" {
+			// blockstrings have already been validated
+			continue
+		}
+		if strings.TrimSpace(obj.Label.Value) == "" {
+			c.errorf(obj.Label.MapKey, "shape text must have a non-empty label")
+			continue
 		}
 	}
 }

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2712,6 +2712,26 @@ object: {
 `,
 			expErr: `d2/testdata/d2compiler/TestCompile/reserved-composite.d2:1:1: reserved field shape does not accept composite`,
 		},
+		{
+			name: "text_no_label",
+			text: `a: "ok" {
+	shape: text
+}
+b: " \n " {
+	shape: text
+}
+
+c: "" {
+	shape: text
+}
+d: "" {
+	shape: circle
+}
+e: " \n "
+`,
+			expErr: `
+`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2732,8 +2732,10 @@ g: |md
 
 |
 `,
-			expErr: `
-`,
+			expErr: `d2/testdata/d2compiler/TestCompile/text_no_label.d2:14:1: block string cannot be empty
+d2/testdata/d2compiler/TestCompile/text_no_label.d2:15:1: block string cannot be empty
+d2/testdata/d2compiler/TestCompile/text_no_label.d2:4:1: shape text must have a non-empty label
+d2/testdata/d2compiler/TestCompile/text_no_label.d2:7:1: shape text must have a non-empty label`,
 		},
 	}
 

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2720,7 +2720,6 @@ object: {
 b: " \n " {
 	shape: text
 }
-
 c: "" {
 	shape: text
 }
@@ -2728,6 +2727,10 @@ d: "" {
 	shape: circle
 }
 e: " \n "
+f: |md  |
+g: |md
+
+|
 `,
 			expErr: `
 `,

--- a/testdata/d2compiler/TestCompile/text_no_label.exp.json
+++ b/testdata/d2compiler/TestCompile/text_no_label.exp.json
@@ -1,0 +1,23 @@
+{
+  "graph": null,
+  "err": {
+    "errs": [
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/text_no_label.d2,13:0:110-13:9:119",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/text_no_label.d2:14:1: block string cannot be empty"
+      },
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/text_no_label.d2,14:0:120-16:1:129",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/text_no_label.d2:15:1: block string cannot be empty"
+      },
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/text_no_label.d2,3:0:25-5:1:51",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/text_no_label.d2:4:1: shape text must have a non-empty label"
+      },
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/text_no_label.d2,6:0:52-8:1:74",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/text_no_label.d2:7:1: shape text must have a non-empty label"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Text shape labels should not be empty.

## Details
- we only validated that labels were not empty for blockstrings, but didn't validate double and single quote labels for shape `text`
- add compile test
- add validation step

