### PR TITLE
fix variable substitution mid-string

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -16,3 +16,4 @@
 - Fixes missing compile error for non-blockstring empty labels [#1590](https://github.com/terrastruct/d2/issues/1590)
 - Fixes multiple constant nears overlapping in some cases [#1591](https://github.com/terrastruct/d2/issues/1591)
 - Fixes error with an empty nested grid [#1594](https://github.com/terrastruct/d2/issues/1594)
+- Fixes incorrect `d2fmt` with variable substitution mid-string [#1611](https://github.com/terrastruct/d2/issues/1611)

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -4061,6 +4061,20 @@ z: {
 `, `d2/testdata/d2compiler/TestCompile2/vars/errors/spread-non-solo.d2:8:2: cannot substitute composite variable "x" as part of a string`)
 				},
 			},
+			{
+				name: "spread-mid-string",
+				run: func(t *testing.T) {
+					assertCompile(t, `
+vars: {
+  test: hello
+}
+
+mybox: {
+  label: prefix${test}suffix
+}
+`, "")
+				},
+			},
 		}
 
 		for _, tc := range tca {

--- a/d2format/format_test.go
+++ b/d2format/format_test.go
@@ -812,6 +812,25 @@ steps: {
 }
 `,
 		},
+		{
+			name: "substitution_mid_string",
+			in: `vars: {
+  test: hello
+}
+
+mybox: {
+  label: prefix${test}suffix
+}
+`,
+			exp: `vars: {
+  test: hello
+}
+
+mybox: {
+  label: prefix${test}suffix
+}
+`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/d2parser/parse.go
+++ b/d2parser/parse.go
@@ -1185,6 +1185,7 @@ func (p *parser) parseUnquotedString(inKey bool) (s *d2ast.UnquotedString) {
 					rawv := rawb.String()
 					s.Value = append(s.Value, d2ast.InterpolationBox{String: &sv, StringRaw: &rawv})
 					sb.Reset()
+					rawb.Reset()
 				}
 				s.Value = append(s.Value, d2ast.InterpolationBox{Substitution: subst})
 				continue

--- a/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.exp.json
+++ b/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.exp.json
@@ -1,0 +1,206 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,0:0:0-8:0:66",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,1:0:1-3:1:24",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,1:0:1-1:4:5",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,1:0:1-1:4:5",
+                    "value": [
+                      {
+                        "string": "vars",
+                        "raw_string": "vars"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,1:6:7-3:1:24",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,2:2:11-2:13:22",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,2:2:11-2:6:15",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,2:2:11-2:6:15",
+                              "value": [
+                                {
+                                  "string": "test",
+                                  "raw_string": "test"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,2:8:17-2:13:22",
+                          "value": [
+                            {
+                              "string": "hello",
+                              "raw_string": "hello"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,5:0:26-7:1:65",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,5:0:26-5:5:31",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,5:0:26-5:5:31",
+                    "value": [
+                      {
+                        "string": "mybox",
+                        "raw_string": "mybox"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,5:7:33-7:1:65",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,6:2:37-6:28:63",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,6:2:37-6:7:42",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,6:2:37-6:7:42",
+                              "value": [
+                                {
+                                  "string": "label",
+                                  "raw_string": "label"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,6:9:44-6:28:63",
+                          "value": [
+                            {
+                              "string": "prefixhellosuffix"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "mybox",
+        "id_val": "mybox",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,5:0:26-5:5:31",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile2/vars/errors/spread-mid-string.d2,5:0:26-5:5:31",
+                    "value": [
+                      {
+                        "string": "mybox",
+                        "raw_string": "mybox"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "prefixhellosuffix"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": null
+}


### PR DESCRIPTION

## Summary

Fixes incorrect d2fmt result with variable substitution in a string.

## Details
- Fixes #1604 
- looks like the raw string buffer wasn't reset
- adds format and compile test for this example

