### PR TITLE
layout + serialization fixes

### DIFF
--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -10,9 +10,10 @@ import (
 )
 
 type SerializedGraph struct {
-	Root    SerializedObject   `json:"root"`
-	Edges   []SerializedEdge   `json:"edges"`
-	Objects []SerializedObject `json:"objects"`
+	Root      SerializedObject   `json:"root"`
+	Edges     []SerializedEdge   `json:"edges"`
+	Objects   []SerializedObject `json:"objects"`
+	RootLevel int                `json:"rootLevel"`
 }
 
 type SerializedObject map[string]interface{}
@@ -30,6 +31,7 @@ func DeserializeGraph(bytes []byte, g *Graph) error {
 	convert(sg.Root, &root)
 	g.Root = &root
 	root.Graph = g
+	g.RootLevel = sg.RootLevel
 
 	idToObj := make(map[string]*Object)
 	idToObj[""] = g.Root
@@ -91,6 +93,7 @@ func SerializeGraph(g *Graph) ([]byte, error) {
 		return nil, err
 	}
 	sg.Root = root
+	sg.RootLevel = g.RootLevel
 
 	var sobjects []SerializedObject
 	for _, o := range g.Objects {

--- a/d2graph/serde.go
+++ b/d2graph/serde.go
@@ -41,6 +41,7 @@ func DeserializeGraph(bytes []byte, g *Graph) error {
 		if err := convert(so, &o); err != nil {
 			return err
 		}
+		o.Graph = g
 		objects = append(objects, &o)
 		idToObj[so["AbsID"].(string)] = &o
 	}

--- a/d2layouts/d2layouts.go
+++ b/d2layouts/d2layouts.go
@@ -101,12 +101,27 @@ func LayoutNested(ctx context.Context, g *d2graph.Graph, graphInfo GraphInfo, co
 			// if we are in a grid diagram, and our children have descendants
 			// we need to run layout on them first, even if they are not special diagram types
 			nestedGraph := ExtractSubgraph(curr, true)
+			id := curr.AbsID()
 			err := LayoutNested(ctx, nestedGraph, GraphInfo{}, coreLayout)
 			if err != nil {
 				return err
 			}
 			InjectNested(g.Root, nestedGraph, false)
 			restoreOrder()
+
+			// need to update curr *Object incase layout changed it
+			var obj *d2graph.Object
+			for _, o := range g.Objects {
+				if o.AbsID() == id {
+					obj = o
+					break
+				}
+			}
+			if obj == nil {
+				return fmt.Errorf("could not find object %#v after layout", id)
+			}
+			curr = obj
+
 			dx := -curr.TopLeft.X
 			dy := -curr.TopLeft.Y
 			for _, o := range nestedGraph.Objects {

--- a/d2layouts/d2layouts.go
+++ b/d2layouts/d2layouts.go
@@ -315,6 +315,9 @@ func InjectNested(container *d2graph.Object, nestedGraph *d2graph.Graph, isRoot 
 	g := container.Graph
 	for _, obj := range nestedGraph.Root.ChildrenArray {
 		obj.Parent = container
+		if container.Children == nil {
+			container.Children = make(map[string]*d2graph.Object)
+		}
 		container.Children[strings.ToLower(obj.ID)] = obj
 		container.ChildrenArray = append(container.ChildrenArray, obj)
 	}


### PR DESCRIPTION

## Summary

Fixes for layout given that coreLayout may need to serialize/deserialize the graph.

## Details
- don't use old Object pointers after graph has been updated from coreLayout
- add rootLevel to graph serialization
- fix deserialization to set Object's graph reference