### PR TITLE
add MkDocs Plugin to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ let us know and we'll be happy to include it here!
 - **Pandoc filter**: [https://github.com/ram02z/d2-filter](https://github.com/ram02z/d2-filter)
 - **Logseq-D2**: [https://github.com/b-yp/logseq-d2](https://github.com/b-yp/logseq-d2)
 - **ent2d2**: [https://github.com/tmc/ent2d2](https://github.com/tmc/ent2d2)
+- **MkDocs Plugin**: [https://github.com/landmaj/mkdocs-d2-plugin](https://github.com/landmaj/mkdocs-d2-plugin)
 
 ### Misc
 


### PR DESCRIPTION
This PR adds [MkDocs Plugin](https://github.com/landmaj/mkdocs-d2-plugin) to the list of community plugins.

At work we are in the process of switching from PlantUML to D2 and I discovered there was no plugin for [MkDocs](https://www.mkdocs.org/), which we use to generate documentation for our clients. So I wrote one. You can see a result of using the plugin [here](https://landmaj.github.io/mkdocs-d2-plugin/).