### PR TITLE
fix invisible null constraints in sql_table

### DIFF
--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -443,7 +443,12 @@ func (c *compiler) compileReserved(attrs *d2graph.Attributes, f *d2ir.Field) {
 				if arr, ok := f.Composite.(*d2ir.Array); ok {
 					for _, constraint := range arr.Values {
 						if scalar, ok := constraint.(*d2ir.Scalar); ok {
-							attrs.Constraint = append(attrs.Constraint, scalar.Value.ScalarString())
+							switch scalar.Value.(type) {
+							case *d2ast.Null:
+								attrs.Constraint = append(attrs.Constraint, "null")
+							default:
+								attrs.Constraint = append(attrs.Constraint, scalar.Value.ScalarString())
+							}
 						}
 					}
 				}

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2200,6 +2200,19 @@ ok: {
 			},
 		},
 		{
+			name: "sql-null-constraint",
+			text: `x: {
+  shape: sql_table
+  a: int {constraint: null}
+  b: int {constraint: [null]}
+}`,
+			assertions: func(t *testing.T, g *d2graph.Graph) {
+				table := g.Objects[0].SQLTable
+				tassert.Nil(t, table.Columns[0].Constraint)
+				tassert.Equal(t, []string{"null"}, table.Columns[1].Constraint)
+			},
+		},
+		{
 			name: "wrong_column_index",
 			text: `Chinchillas: {
   shape: sql_table

--- a/testdata/d2compiler/TestCompile/sql-null-constraint.exp.json
+++ b/testdata/d2compiler/TestCompile/sql-null-constraint.exp.json
@@ -1,0 +1,346 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,0:0:0-4:1:83",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,0:0:0-4:1:83",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,0:3:3-4:1:83",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,1:2:7-1:18:23",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,1:2:7-1:7:12",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,1:2:7-1:7:12",
+                              "value": [
+                                {
+                                  "string": "shape",
+                                  "raw_string": "shape"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,1:9:14-1:18:23",
+                          "value": [
+                            {
+                              "string": "sql_table",
+                              "raw_string": "sql_table"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:2:26-2:27:51",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:2:26-2:3:27",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:2:26-2:3:27",
+                              "value": [
+                                {
+                                  "string": "a",
+                                  "raw_string": "a"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:5:29-2:8:32",
+                          "value": [
+                            {
+                              "string": "int",
+                              "raw_string": "int"
+                            }
+                          ]
+                        }
+                      },
+                      "value": {
+                        "map": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:9:33-2:27:51",
+                          "nodes": [
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:10:34-2:26:50",
+                                "key": {
+                                  "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:10:34-2:20:44",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:10:34-2:20:44",
+                                        "value": [
+                                          {
+                                            "string": "constraint",
+                                            "raw_string": "constraint"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "null": {
+                                    "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,2:22:46-2:26:50"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:2:54-3:29:81",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:2:54-3:3:55",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:2:54-3:3:55",
+                              "value": [
+                                {
+                                  "string": "b",
+                                  "raw_string": "b"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:5:57-3:8:60",
+                          "value": [
+                            {
+                              "string": "int",
+                              "raw_string": "int"
+                            }
+                          ]
+                        }
+                      },
+                      "value": {
+                        "map": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:9:61-3:29:81",
+                          "nodes": [
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:10:62-3:28:80",
+                                "key": {
+                                  "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:10:62-3:20:72",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:10:62-3:20:72",
+                                        "value": [
+                                          {
+                                            "string": "constraint",
+                                            "raw_string": "constraint"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "array": {
+                                    "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:22:74-3:27:79",
+                                    "nodes": [
+                                      {
+                                        "null": {
+                                          "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,3:23:75-3:27:79"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "x",
+        "id_val": "x",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/sql-null-constraint.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "sql_table": {
+          "columns": [
+            {
+              "name": {
+                "label": "a",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "type": {
+                "label": "int",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "constraint": null,
+              "reference": ""
+            },
+            {
+              "name": {
+                "label": "b",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "type": {
+                "label": "int",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "constraint": [
+                "null"
+              ],
+              "reference": ""
+            }
+          ]
+        },
+        "attributes": {
+          "label": {
+            "value": "x"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "sql_table"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": null
+}


### PR DESCRIPTION
Thix PR fixes issue #1655 

## Diagram
```d2
table: {
    shape: sql_table
    a: int {constraint: null}
    b: int {constraint: [TRUE; False; null; NULL]}
}
```

## Before
<img width="894" alt="before" src="https://github.com/terrastruct/d2/assets/13437951/75c87a6d-b7dd-4ad6-a19d-849d565d336e">

## After
<img width="1186" alt="after" src="https://github.com/terrastruct/d2/assets/13437951/06684122-6dbb-4987-bb7c-bfe8e072d95b">


## Summary

The behavior of null, when used in arrays, is now consistent with how other types work. When used as the only constraint (without array), only types which implement `d2ast.String` are allowed. Null is also allowed but does nothing, as expected. In arrays all types are allowed but booleans are converted to lower case. Null was previously converted to an empty string, this PR changes it to lower case string "null".

This could also be fixed by changing return value of `ScalarString()` method for `Null` type. I tried it and all tests pass,  however there is this commit: https://github.com/terrastruct/d2/commit/9d0c73cef2e51da0565e09cce2b25b187cad0029

Another solution would be to disallow everything but `d2ast.String` in constraint arrays, to keep it consistent with how non-array constraints work, however this could break existing diagrams and prevent them from compiling. Let me know if you would prefer this solution.
