### PR TITLE
lib/color: avoid unnecessary byte/string conversion

### DIFF
--- a/lib/color/color.go
+++ b/lib/color/color.go
@@ -14,7 +14,7 @@ import (
 var themeColorRegex = regexp.MustCompile(`^(N[1-7]|B[1-6]|AA[245]|AB[45])$`)
 
 func IsThemeColor(colorString string) bool {
-	return themeColorRegex.Match([]byte(colorString))
+	return themeColorRegex.MatchString(colorString)
 }
 
 func Darken(colorString string) (string, error) {


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance gain.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := themeColorRegex.Match([]byte("N1")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := themeColorRegex.MatchString("N1"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: oss.terrastruct.com/d2/lib/color
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 9894165	       114.3 ns/op	       2 B/op	       1 allocs/op
BenchmarkMatchString-16    	13439838	        83.61 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	oss.terrastruct.com/d2/lib/color	3.306s
```

<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
