### PR TITLE
remove imgbundler's xmain.State dependency

### DIFF
--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -434,7 +434,7 @@ func compile(ctx context.Context, ms *xmain.State, plugins []d2plugin.Plugin, la
 		if err != nil {
 			return nil, false, err
 		}
-		out, err := xgif.AnimatePNGs(ms, pngs, int(animateInterval))
+		out, err := AnimatePNGs(ms, pngs, int(animateInterval))
 		if err != nil {
 			return nil, false, err
 		}
@@ -769,7 +769,7 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opts 
 			bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		}
 
-		out, err = png.ConvertSVG(ms, page, svg)
+		out, err = ConvertSVG(ms, page, svg)
 		if err != nil {
 			return svg, err
 		}
@@ -843,7 +843,7 @@ func renderPDF(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opt
 		}
 		svg = appendix.Append(diagram, ruler, svg)
 
-		pngImg, err := png.ConvertSVG(ms, page, svg)
+		pngImg, err := ConvertSVG(ms, page, svg)
 		if err != nil {
 			return svg, err
 		}
@@ -945,7 +945,7 @@ func renderPPTX(ctx context.Context, ms *xmain.State, presentation *pptx.Present
 
 		svg = appendix.Append(diagram, ruler, svg)
 
-		pngImg, err := png.ConvertSVG(ms, page, svg)
+		pngImg, err := ConvertSVG(ms, page, svg)
 		if err != nil {
 			return nil, err
 		}
@@ -1191,7 +1191,7 @@ func renderPNGsForGIF(ctx context.Context, ms *xmain.State, plugin d2plugin.Plug
 
 		svg = appendix.Append(diagram, ruler, svg)
 
-		pngImg, err := png.ConvertSVG(ms, page, svg)
+		pngImg, err := ConvertSVG(ms, page, svg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1221,4 +1221,22 @@ func renderPNGsForGIF(ctx context.Context, ms *xmain.State, plugin d2plugin.Plug
 	}
 
 	return svg, pngs, nil
+}
+
+func ConvertSVG(ms *xmain.State, page playwright.Page, svg []byte) ([]byte, error) {
+	cancel := background.Repeat(func() {
+		ms.Log.Info.Printf("converting to PNG...")
+	}, time.Second*5)
+	defer cancel()
+
+	return png.ConvertSVG(page, svg)
+}
+
+func AnimatePNGs(ms *xmain.State, pngs [][]byte, animIntervalMs int) ([]byte, error) {
+	cancel := background.Repeat(func() {
+		ms.Log.Info.Printf("generating GIF...")
+	}, time.Second*5)
+	defer cancel()
+
+	return xgif.AnimatePNGs(pngs, animIntervalMs)
 }

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -748,10 +748,11 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opts 
 		return svg, err
 	}
 
-	svg, bundleErr := imgbundler.BundleLocal(ctx, ms, svg)
+	cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
+	svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
 	if bundle {
 		var bundleErr2 error
-		svg, bundleErr2 = imgbundler.BundleRemote(ctx, ms, svg)
+		svg, bundleErr2 = imgbundler.BundleRemote(ctx, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 	}
 	if forceAppendix && !toPNG {
@@ -764,7 +765,7 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opts 
 
 		if !bundle {
 			var bundleErr2 error
-			svg, bundleErr2 = imgbundler.BundleRemote(ctx, ms, svg)
+			svg, bundleErr2 = imgbundler.BundleRemote(ctx, svg, cacheImages)
 			bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		}
 
@@ -833,8 +834,9 @@ func renderPDF(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opt
 			return svg, err
 		}
 
-		svg, bundleErr := imgbundler.BundleLocal(ctx, ms, svg)
-		svg, bundleErr2 := imgbundler.BundleRemote(ctx, ms, svg)
+		cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
+		svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
+		svg, bundleErr2 := imgbundler.BundleRemote(ctx, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		if bundleErr != nil {
 			return svg, bundleErr
@@ -933,8 +935,9 @@ func renderPPTX(ctx context.Context, ms *xmain.State, presentation *pptx.Present
 			return nil, err
 		}
 
-		svg, bundleErr := imgbundler.BundleLocal(ctx, ms, svg)
-		svg, bundleErr2 := imgbundler.BundleRemote(ctx, ms, svg)
+		cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
+		svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
+		svg, bundleErr2 := imgbundler.BundleRemote(ctx, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		if bundleErr != nil {
 			return nil, bundleErr
@@ -1178,8 +1181,9 @@ func renderPNGsForGIF(ctx context.Context, ms *xmain.State, plugin d2plugin.Plug
 			return nil, nil, err
 		}
 
-		svg, bundleErr := imgbundler.BundleLocal(ctx, ms, svg)
-		svg, bundleErr2 := imgbundler.BundleRemote(ctx, ms, svg)
+		cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
+		svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
+		svg, bundleErr2 := imgbundler.BundleRemote(ctx, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		if bundleErr != nil {
 			return nil, nil, bundleErr

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -37,6 +37,7 @@ import (
 	"oss.terrastruct.com/d2/lib/pdf"
 	"oss.terrastruct.com/d2/lib/png"
 	"oss.terrastruct.com/d2/lib/pptx"
+	"oss.terrastruct.com/d2/lib/simplelog"
 	"oss.terrastruct.com/d2/lib/textmeasure"
 	timelib "oss.terrastruct.com/d2/lib/time"
 	"oss.terrastruct.com/d2/lib/version"
@@ -749,10 +750,11 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opts 
 	}
 
 	cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
-	svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
+	l := simplelog.FromCmdLog(ms.Log)
+	svg, bundleErr := imgbundler.BundleLocal(ctx, l, svg, cacheImages)
 	if bundle {
 		var bundleErr2 error
-		svg, bundleErr2 = imgbundler.BundleRemote(ctx, svg, cacheImages)
+		svg, bundleErr2 = imgbundler.BundleRemote(ctx, l, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 	}
 	if forceAppendix && !toPNG {
@@ -765,7 +767,7 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opts 
 
 		if !bundle {
 			var bundleErr2 error
-			svg, bundleErr2 = imgbundler.BundleRemote(ctx, svg, cacheImages)
+			svg, bundleErr2 = imgbundler.BundleRemote(ctx, l, svg, cacheImages)
 			bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		}
 
@@ -835,8 +837,9 @@ func renderPDF(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opt
 		}
 
 		cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
-		svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
-		svg, bundleErr2 := imgbundler.BundleRemote(ctx, svg, cacheImages)
+		l := simplelog.FromCmdLog(ms.Log)
+		svg, bundleErr := imgbundler.BundleLocal(ctx, l, svg, cacheImages)
+		svg, bundleErr2 := imgbundler.BundleRemote(ctx, l, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		if bundleErr != nil {
 			return svg, bundleErr
@@ -936,8 +939,9 @@ func renderPPTX(ctx context.Context, ms *xmain.State, presentation *pptx.Present
 		}
 
 		cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
-		svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
-		svg, bundleErr2 := imgbundler.BundleRemote(ctx, svg, cacheImages)
+		l := simplelog.FromCmdLog(ms.Log)
+		svg, bundleErr := imgbundler.BundleLocal(ctx, l, svg, cacheImages)
+		svg, bundleErr2 := imgbundler.BundleRemote(ctx, l, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		if bundleErr != nil {
 			return nil, bundleErr
@@ -1182,8 +1186,9 @@ func renderPNGsForGIF(ctx context.Context, ms *xmain.State, plugin d2plugin.Plug
 		}
 
 		cacheImages := ms.Env.Getenv("IMG_CACHE") == "1"
-		svg, bundleErr := imgbundler.BundleLocal(ctx, svg, cacheImages)
-		svg, bundleErr2 := imgbundler.BundleRemote(ctx, svg, cacheImages)
+		l := simplelog.FromCmdLog(ms.Log)
+		svg, bundleErr := imgbundler.BundleLocal(ctx, l, svg, cacheImages)
+		svg, bundleErr2 := imgbundler.BundleRemote(ctx, l, svg, cacheImages)
 		bundleErr = multierr.Combine(bundleErr, bundleErr2)
 		if bundleErr != nil {
 			return nil, nil, bundleErr

--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -19,8 +19,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/util-go/xdefer"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 var imgCache sync.Map
@@ -29,12 +29,12 @@ const maxImageSize int64 = 1 << 25 // 33_554_432
 
 var imageRegex = regexp.MustCompile(`<image href="([^"]+)"`)
 
-func BundleLocal(ctx context.Context, ms *xmain.State, in []byte) ([]byte, error) {
-	return bundle(ctx, ms, in, false)
+func BundleLocal(ctx context.Context, in []byte, cacheImages bool) ([]byte, error) {
+	return bundle(ctx, in, false, cacheImages)
 }
 
-func BundleRemote(ctx context.Context, ms *xmain.State, in []byte) ([]byte, error) {
-	return bundle(ctx, ms, in, true)
+func BundleRemote(ctx context.Context, in []byte, cacheImages bool) ([]byte, error) {
+	return bundle(ctx, in, true, cacheImages)
 }
 
 type repl struct {
@@ -42,7 +42,7 @@ type repl struct {
 	to   []byte
 }
 
-func bundle(ctx context.Context, ms *xmain.State, svg []byte, isRemote bool) (_ []byte, err error) {
+func bundle(ctx context.Context, svg []byte, isRemote, cacheImages bool) (_ []byte, err error) {
 	if isRemote {
 		defer xdefer.Errorf(&err, "failed to bundle remote images")
 	} else {
@@ -54,7 +54,7 @@ func bundle(ctx context.Context, ms *xmain.State, svg []byte, isRemote bool) (_ 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
 
-	return runWorkers(ctx, ms, svg, imgs, isRemote)
+	return runWorkers(ctx, svg, imgs, isRemote, cacheImages)
 }
 
 // filterImageElements finds all unique image elements in imgs that are
@@ -84,7 +84,7 @@ func filterImageElements(imgs [][][]byte, isRemote bool) [][][]byte {
 	return imgs2
 }
 
-func runWorkers(ctx context.Context, ms *xmain.State, svg []byte, imgs [][][]byte, isRemote bool) (_ []byte, err error) {
+func runWorkers(ctx context.Context, svg []byte, imgs [][][]byte, isRemote, cacheImages bool) (_ []byte, err error) {
 	var wg sync.WaitGroup
 	replc := make(chan repl)
 
@@ -111,9 +111,9 @@ func runWorkers(ctx context.Context, ms *xmain.State, svg []byte, imgs [][][]byt
 					<-sema
 				}()
 
-				bundledImage, err := worker(ctx, ms, img[1], isRemote)
+				bundledImage, err := worker(ctx, img[1], isRemote, cacheImages)
 				if err != nil {
-					ms.Log.Error.Printf("failed to bundle %s: %v", img[1], err)
+					log.Error(ctx, fmt.Sprintf("failed to bundle %s: %v", img[1], err))
 					errhrefsMu.Lock()
 					errhrefs = append(errhrefs, string(img[1]))
 					errhrefsMu.Unlock()
@@ -137,7 +137,7 @@ func runWorkers(ctx context.Context, ms *xmain.State, svg []byte, imgs [][][]byt
 		case <-ctx.Done():
 			return svg, xerrors.Errorf("failed to wait for workers: %w", ctx.Err())
 		case <-t.C:
-			ms.Log.Info.Printf("fetching images...")
+			log.Info(ctx, "fetching images...")
 		case repl, ok := <-replc:
 			if !ok {
 				if len(errhrefs) > 0 {
@@ -150,8 +150,8 @@ func runWorkers(ctx context.Context, ms *xmain.State, svg []byte, imgs [][][]byt
 	}
 }
 
-func worker(ctx context.Context, ms *xmain.State, href []byte, isRemote bool) ([]byte, error) {
-	if ms.Env.Getenv("IMG_CACHE") == "1" {
+func worker(ctx context.Context, href []byte, isRemote, cacheImages bool) ([]byte, error) {
+	if cacheImages {
 		if hit, ok := imgCache.Load(string(href)); ok {
 			return hit.([]byte), nil
 		}
@@ -160,10 +160,10 @@ func worker(ctx context.Context, ms *xmain.State, href []byte, isRemote bool) ([
 	var mimeType string
 	var err error
 	if isRemote {
-		ms.Log.Debug.Printf("fetching %s remotely", string(href))
+		log.Debug(ctx, fmt.Sprintf("fetching %s remotely", string(href)))
 		buf, mimeType, err = httpGet(ctx, html.UnescapeString(string(href)))
 	} else {
-		ms.Log.Debug.Printf("reading %s from disk", string(href))
+		log.Debug(ctx, fmt.Sprintf("reading %s from disk", string(href)))
 		buf, err = os.ReadFile(html.UnescapeString(string(href)))
 	}
 	if err != nil {
@@ -177,7 +177,7 @@ func worker(ctx context.Context, ms *xmain.State, href []byte, isRemote bool) ([
 	b64 := base64.StdEncoding.EncodeToString(buf)
 
 	out := []byte(fmt.Sprintf(`<image href="data:%s;base64,%s"`, mimeType, b64))
-	if ms.Env.Getenv("IMG_CACHE") == "1" {
+	if cacheImages {
 		imgCache.Store(string(href), out)
 	}
 	return out, nil

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -16,6 +16,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 
 	"oss.terrastruct.com/d2/lib/log"
+	"oss.terrastruct.com/d2/lib/simplelog"
 )
 
 //go:embed test_png.png
@@ -96,7 +97,8 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		return respRecorder.Result()
 	})
 
-	out, err := BundleRemote(ctx, []byte(sampleSVG), false)
+	l := simplelog.FromLibLog(ctx)
+	out, err := BundleRemote(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +122,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(200)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
+	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +137,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(200)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
+	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -147,7 +149,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(500)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
+	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -192,7 +194,8 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 }]]></style></svg>
 `, svgURL, pngURL)
 
-	out, err := BundleLocal(ctx, []byte(sampleSVG), false)
+	l := simplelog.FromLibLog(ctx)
+	out, err := BundleLocal(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +254,8 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		return respRecorder.Result()
 	})
 
-	out, err := BundleRemote(ctx, []byte(sampleSVG), false)
+	l := simplelog.FromLibLog(ctx)
+	out, err := BundleRemote(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,12 +309,13 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		return respRecorder.Result()
 	})
 
+	l := simplelog.FromLibLog(ctx)
 	// Using a cache, imgs are not refetched on multiple runs
-	_, err := BundleRemote(ctx, []byte(sampleSVG), true)
+	_, err := BundleRemote(ctx, l, []byte(sampleSVG), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = BundleRemote(ctx, []byte(sampleSVG), true)
+	_, err = BundleRemote(ctx, l, []byte(sampleSVG), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,11 +323,11 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 
 	// With cache disabled, it refetches
 	count = 0
-	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
+	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
+	_, err = BundleRemote(ctx, l, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -109,7 +109,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		return respRecorder.Result()
 	})
 
-	out, err := BundleRemote(ctx, ms, []byte(sampleSVG))
+	out, err := BundleRemote(ctx, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(200)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, ms, []byte(sampleSVG))
+	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(200)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, ms, []byte(sampleSVG))
+	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -160,7 +160,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		respRecorder.WriteHeader(500)
 		return respRecorder.Result()
 	})
-	_, err = BundleRemote(ctx, ms, []byte(sampleSVG))
+	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -215,7 +215,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		Env: xos.NewEnv(os.Environ()),
 	}
 	ms.Log = cmdlog.NewTB(ms.Env, t)
-	out, err := BundleLocal(ctx, ms, []byte(sampleSVG))
+	out, err := BundleLocal(ctx, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 		return respRecorder.Result()
 	})
 
-	out, err := BundleRemote(ctx, ms, []byte(sampleSVG))
+	out, err := BundleRemote(ctx, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,25 +351,23 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	})
 
 	// Using a cache, imgs are not refetched on multiple runs
-	ms.Env.Setenv("IMG_CACHE", "1")
-	_, err := BundleRemote(ctx, ms, []byte(sampleSVG))
+	_, err := BundleRemote(ctx, []byte(sampleSVG), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = BundleRemote(ctx, ms, []byte(sampleSVG))
+	_, err = BundleRemote(ctx, []byte(sampleSVG), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	tassert.Equal(t, 1, count)
 
 	// With cache disabled, it refetches
-	ms.Env.Setenv("IMG_CACHE", "0")
 	count = 0
-	_, err = BundleRemote(ctx, ms, []byte(sampleSVG))
+	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = BundleRemote(ctx, ms, []byte(sampleSVG))
+	_, err = BundleRemote(ctx, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"cdr.dev/slog/sloggers/slogtest"
 	tassert "github.com/stretchr/testify/assert"
 
 	"oss.terrastruct.com/d2/lib/log"
@@ -49,7 +50,8 @@ func TestRegex(t *testing.T) {
 
 func TestInlineRemote(t *testing.T) {
 	imgCache = sync.Map{}
-	ctx := log.WithTB(context.Background(), t, nil)
+	// we don't want log.Error to cause this test to fail
+	ctx := log.WithTB(context.Background(), t, &slogtest.Options{IgnoreErrors: true})
 	svgURL := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	pngURL := "https://cdn4.iconfinder.com/data/icons/smart-phones-technologies/512/android-phone.png"
 

--- a/lib/imgbundler/imgbundler_test.go
+++ b/lib/imgbundler/imgbundler_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -15,10 +14,7 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
-	"oss.terrastruct.com/util-go/cmdlog"
-	"oss.terrastruct.com/util-go/xos"
-
-	"oss.terrastruct.com/util-go/xmain"
+	"oss.terrastruct.com/d2/lib/log"
 )
 
 //go:embed test_png.png
@@ -53,7 +49,7 @@ func TestRegex(t *testing.T) {
 
 func TestInlineRemote(t *testing.T) {
 	imgCache = sync.Map{}
-	ctx := context.Background()
+	ctx := log.WithTB(context.Background(), t, nil)
 	svgURL := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	pngURL := "https://cdn4.iconfinder.com/data/icons/smart-phones-technologies/512/android-phone.png"
 
@@ -83,17 +79,6 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	src: url("REMOVED");
 }]]></style></svg>
 `, svgURL, pngURL)
-
-	ms := &xmain.State{
-		Name: "test",
-
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-
-		Env: xos.NewEnv(os.Environ()),
-	}
-	ms.Log = cmdlog.NewTB(ms.Env, t)
 
 	httpClient.Transport = roundTripFunc(func(req *http.Request) *http.Response {
 		respRecorder := httptest.NewRecorder()
@@ -168,7 +153,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 
 func TestInlineLocal(t *testing.T) {
 	imgCache = sync.Map{}
-	ctx := context.Background()
+	ctx := log.WithTB(context.Background(), t, nil)
 	svgURL, err := filepath.Abs("./test_svg.svg")
 	if err != nil {
 		t.Fatal(err)
@@ -205,16 +190,6 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 }]]></style></svg>
 `, svgURL, pngURL)
 
-	ms := &xmain.State{
-		Name: "test",
-
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-
-		Env: xos.NewEnv(os.Environ()),
-	}
-	ms.Log = cmdlog.NewTB(ms.Env, t)
 	out, err := BundleLocal(ctx, []byte(sampleSVG), false)
 	if err != nil {
 		t.Fatal(err)
@@ -233,7 +208,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 // TestDuplicateURL ensures that we don't fetch the same image twice
 func TestDuplicateURL(t *testing.T) {
 	imgCache = sync.Map{}
-	ctx := context.Background()
+	ctx := log.WithTB(context.Background(), t, nil)
 	url1 := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	url2 := "https://icons.terrastruct.com/essentials/004-picture.svg"
 
@@ -263,17 +238,6 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	src: url("REMOVED");
 }]]></style></svg>
 `, url1, url2)
-
-	ms := &xmain.State{
-		Name: "test",
-
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-
-		Env: xos.NewEnv(os.Environ()),
-	}
-	ms.Log = cmdlog.NewTB(ms.Env, t)
 
 	count := 0
 
@@ -298,7 +262,7 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 
 func TestImgCache(t *testing.T) {
 	imgCache = sync.Map{}
-	ctx := context.Background()
+	ctx := log.WithTB(context.Background(), t, nil)
 	url1 := "https://icons.terrastruct.com/essentials/004-picture.svg"
 	url2 := "https://icons.terrastruct.com/essentials/004-picture.svg"
 
@@ -328,17 +292,6 @@ width="328" height="587" viewBox="-100 -131 328 587"><style type="text/css">
 	src: url("REMOVED");
 }]]></style></svg>
 `, url1, url2)
-
-	ms := &xmain.State{
-		Name: "test",
-
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-
-		Env: xos.NewEnv(os.Environ()),
-	}
-	ms.Log = cmdlog.NewTB(ms.Env, t)
 
 	count := 0
 

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
-	"time"
 
 	_ "embed"
 
@@ -14,9 +13,7 @@ import (
 	pngstruct "github.com/dsoprea/go-png-image-structure/v2"
 	"github.com/playwright-community/playwright-go"
 
-	"oss.terrastruct.com/d2/lib/background"
 	"oss.terrastruct.com/d2/lib/version"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 // ConvertSVG scales the image by 2x
@@ -88,12 +85,7 @@ const pngPrefix = "data:image/png;base64,"
 
 // ConvertSVG converts the given SVG into a PNG.
 // Note that the resulting PNG has 2x the size (width and height) of the original SVG (see generate_png.js)
-func ConvertSVG(ms *xmain.State, page playwright.Page, svg []byte) ([]byte, error) {
-	cancel := background.Repeat(func() {
-		ms.Log.Info.Printf("converting to PNG...")
-	}, time.Second*5)
-	defer cancel()
-
+func ConvertSVG(page playwright.Page, svg []byte) ([]byte, error) {
 	encodedSVG := base64.StdEncoding.EncodeToString(svg)
 	pngInterface, err := page.Evaluate(genPNGScript, map[string]interface{}{
 		"imgString": "data:image/svg+xml;charset=utf-8;base64," + encodedSVG,

--- a/lib/simplelog/simplelog.go
+++ b/lib/simplelog/simplelog.go
@@ -1,0 +1,71 @@
+// Package simplelog contains a very simple interface for logging strings at either Debug, Info, or Error levels
+package simplelog
+
+import (
+	"context"
+
+	"oss.terrastruct.com/d2/lib/log"
+	"oss.terrastruct.com/util-go/cmdlog"
+)
+
+type Logger interface {
+	Debug(string)
+	Info(string)
+	Error(string)
+}
+
+type logger struct {
+	logDebug *func(string)
+	logInfo  *func(string)
+	logError *func(string)
+}
+
+func (l logger) Debug(s string) {
+	if l.logDebug != nil {
+		(*l.logDebug)(s)
+	}
+}
+func (l logger) Info(s string) {
+	if l.logInfo != nil {
+		(*l.logInfo)(s)
+	}
+}
+func (l logger) Error(s string) {
+	if l.logError != nil {
+		(*l.logError)(s)
+	}
+}
+
+func Make(logDebug, logInfo, logError *func(string)) Logger {
+	return logger{
+		logDebug: logDebug,
+		logInfo:  logInfo,
+		logError: logError,
+	}
+}
+
+func FromLibLog(ctx context.Context) Logger {
+	lDebug := func(s string) {
+		log.Debug(ctx, s)
+	}
+	lInfo := func(s string) {
+		log.Info(ctx, s)
+	}
+	lError := func(s string) {
+		log.Error(ctx, s)
+	}
+	return Make(&lDebug, &lInfo, &lError)
+}
+
+func FromCmdLog(cl *cmdlog.Logger) Logger {
+	lDebug := func(s string) {
+		cl.Debug.Print(s)
+	}
+	lInfo := func(s string) {
+		cl.Info.Print(s)
+	}
+	lError := func(s string) {
+		cl.Error.Print(s)
+	}
+	return Make(&lDebug, &lInfo, &lError)
+}

--- a/lib/xgif/xgif.go
+++ b/lib/xgif/xgif.go
@@ -15,27 +15,17 @@ import (
 	"image/color"
 	"image/gif"
 	"image/png"
-	"time"
 
 	"github.com/ericpauley/go-quantize/quantize"
 
-	"oss.terrastruct.com/d2/lib/background"
 	"oss.terrastruct.com/util-go/go2"
-	"oss.terrastruct.com/util-go/xmain"
 )
 
 const INFINITE_LOOP = 0
 
 var BG_COLOR = color.White
 
-func AnimatePNGs(ms *xmain.State, pngs [][]byte, animIntervalMs int) ([]byte, error) {
-	if ms != nil {
-		cancel := background.Repeat(func() {
-			ms.Log.Info.Printf("generating GIF...")
-		}, time.Second*5)
-		defer cancel()
-	}
-
+func AnimatePNGs(pngs [][]byte, animIntervalMs int) ([]byte, error) {
 	var width, height int
 	pngImgs := make([]image.Image, len(pngs))
 	for i, pngBytes := range pngs {

--- a/lib/xgif/xgif_test.go
+++ b/lib/xgif/xgif_test.go
@@ -20,7 +20,7 @@ var test_output []byte
 func TestPngToGif(t *testing.T) {
 	boards := [][]byte{test_input1, test_input2}
 	interval := 1_000
-	gifBytes, err := AnimatePNGs(nil, boards, interval)
+	gifBytes, err := AnimatePNGs(boards, interval)
 	assert.NoError(t, err)
 
 	// use this to update the test output


### PR DESCRIPTION
## Summary

Update imgbundler lib functions to no longer have xmain.State as a dependency.

## Details
- adds `cacheImages` flag to `BundleLocal` and `BundleRemote` instead of reading from `ms.Env`
- updates logging to use new simplelog interface instead of ms.Log
- xmain.State shouldn't be a dependency of a lib func