### PR TITLE
fix d2fonts race condition in TestCLI_E2E

### DIFF
--- a/d2renderers/d2fonts/d2fonts.go
+++ b/d2renderers/d2fonts/d2fonts.go
@@ -45,7 +45,7 @@ func (f Font) GetEncodedSubset(corpus string) string {
 
 	FontFamiliesMu.Lock()
 	defer FontFamiliesMu.Unlock()
-	face := FontFaces.MustGet(f)
+	face := FontFaces.Get(f)
 	fontBuf := make([]byte, len(face))
 	copy(fontBuf, face)
 	fontBuf = font.UTF8CutFont(fontBuf, uniqueChars)
@@ -53,7 +53,7 @@ func (f Font) GetEncodedSubset(corpus string) string {
 	fontBuf, err := fontlib.Sfnt2Woff(fontBuf)
 	if err != nil {
 		// If subset fails, return full encoding
-		return FontEncodings.MustGet(f)
+		return FontEncodings.Get(f)
 	}
 
 	return fmt.Sprintf("data:application/font-woff;base64,%v", base64.StdEncoding.EncodeToString(fontBuf))
@@ -366,8 +366,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_REGULAR,
 		}
-		FontFaces.Set(regularFont, FontFaces.MustGet(fallbackFont))
-		FontEncodings.Set(regularFont, FontEncodings.MustGet(fallbackFont))
+		FontFaces.Set(regularFont, FontFaces.Get(fallbackFont))
+		FontEncodings.Set(regularFont, FontEncodings.Get(fallbackFont))
 	}
 
 	italicFont := Font{
@@ -384,8 +384,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_ITALIC,
 		}
-		FontFaces.Set(italicFont, FontFaces.MustGet(fallbackFont))
-		FontEncodings.Set(italicFont, FontEncodings.MustGet(fallbackFont))
+		FontFaces.Set(italicFont, FontFaces.Get(fallbackFont))
+		FontEncodings.Set(italicFont, FontEncodings.Get(fallbackFont))
 	}
 
 	boldFont := Font{
@@ -402,8 +402,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_BOLD,
 		}
-		FontFaces.Set(boldFont, FontFaces.MustGet(fallbackFont))
-		FontEncodings.Set(boldFont, FontEncodings.MustGet(fallbackFont))
+		FontFaces.Set(boldFont, FontFaces.Get(fallbackFont))
+		FontEncodings.Set(boldFont, FontEncodings.Get(fallbackFont))
 	}
 
 	semiboldFont := Font{
@@ -420,8 +420,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_SEMIBOLD,
 		}
-		FontFaces.Set(semiboldFont, FontFaces.MustGet(fallbackFont))
-		FontEncodings.Set(semiboldFont, FontEncodings.MustGet(fallbackFont))
+		FontFaces.Set(semiboldFont, FontFaces.Get(fallbackFont))
+		FontEncodings.Set(semiboldFont, FontEncodings.Get(fallbackFont))
 	}
 
 	FontFamilies = append(FontFamilies, customFontFamily)

--- a/d2renderers/d2fonts/d2fonts.go
+++ b/d2renderers/d2fonts/d2fonts.go
@@ -45,7 +45,7 @@ func (f Font) GetEncodedSubset(corpus string) string {
 
 	FontFamiliesMu.Lock()
 	defer FontFamiliesMu.Unlock()
-	face := FontFaces.Get(f)
+	face := FontFaces.MustGet(f)
 	fontBuf := make([]byte, len(face))
 	copy(fontBuf, face)
 	fontBuf = font.UTF8CutFont(fontBuf, uniqueChars)
@@ -53,7 +53,7 @@ func (f Font) GetEncodedSubset(corpus string) string {
 	fontBuf, err := fontlib.Sfnt2Woff(fontBuf)
 	if err != nil {
 		// If subset fails, return full encoding
-		return FontEncodings.Get(f)
+		return FontEncodings.MustGet(f)
 	}
 
 	return fmt.Sprintf("data:application/font-woff;base64,%v", base64.StdEncoding.EncodeToString(fontBuf))
@@ -366,8 +366,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_REGULAR,
 		}
-		FontFaces.Set(regularFont, FontFaces.Get(fallbackFont))
-		FontEncodings.Set(regularFont, FontEncodings.Get(fallbackFont))
+		FontFaces.Set(regularFont, FontFaces.MustGet(fallbackFont))
+		FontEncodings.Set(regularFont, FontEncodings.MustGet(fallbackFont))
 	}
 
 	italicFont := Font{
@@ -384,8 +384,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_ITALIC,
 		}
-		FontFaces.Set(italicFont, FontFaces.Get(fallbackFont))
-		FontEncodings.Set(italicFont, FontEncodings.Get(fallbackFont))
+		FontFaces.Set(italicFont, FontFaces.MustGet(fallbackFont))
+		FontEncodings.Set(italicFont, FontEncodings.MustGet(fallbackFont))
 	}
 
 	boldFont := Font{
@@ -402,8 +402,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_BOLD,
 		}
-		FontFaces.Set(boldFont, FontFaces.Get(fallbackFont))
-		FontEncodings.Set(boldFont, FontEncodings.Get(fallbackFont))
+		FontFaces.Set(boldFont, FontFaces.MustGet(fallbackFont))
+		FontEncodings.Set(boldFont, FontEncodings.MustGet(fallbackFont))
 	}
 
 	semiboldFont := Font{
@@ -420,8 +420,8 @@ func AddFontFamily(name string, regularTTF, italicTTF, boldTTF, semiboldTTF []by
 			Family: SourceSansPro,
 			Style:  FONT_STYLE_SEMIBOLD,
 		}
-		FontFaces.Set(semiboldFont, FontFaces.Get(fallbackFont))
-		FontEncodings.Set(semiboldFont, FontEncodings.Get(fallbackFont))
+		FontFaces.Set(semiboldFont, FontFaces.MustGet(fallbackFont))
+		FontEncodings.Set(semiboldFont, FontEncodings.MustGet(fallbackFont))
 	}
 
 	FontFamilies = append(FontFamilies, customFontFamily)

--- a/d2renderers/d2fonts/d2fonts_test.go
+++ b/d2renderers/d2fonts/d2fonts_test.go
@@ -14,7 +14,7 @@ func TestCutFont(t *testing.T) {
 		Family: SourceCodePro,
 		Style:  FONT_STYLE_BOLD,
 	}
-	face := FontFaces.Get(f)
+	face := FontFaces.MustGet(f)
 	fontBuf := make([]byte, len(face))
 	copy(fontBuf, face)
 	fontBuf = font.UTF8CutFont(fontBuf, " 1")

--- a/d2renderers/d2fonts/d2fonts_test.go
+++ b/d2renderers/d2fonts/d2fonts_test.go
@@ -14,11 +14,7 @@ func TestCutFont(t *testing.T) {
 		Family: SourceCodePro,
 		Style:  FONT_STYLE_BOLD,
 	}
-	var face []byte
-	{
-		ff, _ := FontFaces.Load(f)
-		face = ff.([]byte)
-	}
+	face := FontFaces.Get(f)
 	fontBuf := make([]byte, len(face))
 	copy(fontBuf, face)
 	fontBuf = font.UTF8CutFont(fontBuf, " 1")

--- a/d2renderers/d2fonts/d2fonts_test.go
+++ b/d2renderers/d2fonts/d2fonts_test.go
@@ -14,8 +14,13 @@ func TestCutFont(t *testing.T) {
 		Family: SourceCodePro,
 		Style:  FONT_STYLE_BOLD,
 	}
-	fontBuf := make([]byte, len(FontFaces[f]))
-	copy(fontBuf, FontFaces[f])
+	var face []byte
+	{
+		ff, _ := FontFaces.Load(f)
+		face = ff.([]byte)
+	}
+	fontBuf := make([]byte, len(face))
+	copy(fontBuf, face)
 	fontBuf = font.UTF8CutFont(fontBuf, " 1")
 	err := diff.Testdata(filepath.Join("testdata", "d2fonts", "cut"), ".txt", fontBuf)
 	assert.Success(t, err)

--- a/d2renderers/d2fonts/d2fonts_test.go
+++ b/d2renderers/d2fonts/d2fonts_test.go
@@ -14,7 +14,7 @@ func TestCutFont(t *testing.T) {
 		Family: SourceCodePro,
 		Style:  FONT_STYLE_BOLD,
 	}
-	face := FontFaces.MustGet(f)
+	face := FontFaces.Get(f)
 	fontBuf := make([]byte, len(face))
 	copy(fontBuf, face)
 	fontBuf = font.UTF8CutFont(fontBuf, " 1")

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -129,7 +129,7 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-regular;
 	src: url("%s");
 }
-]]></style>`, d2fonts.FontEncodings.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+]]></style>`, d2fonts.FontEncodings.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
 	}
 	if !strings.Contains(svg, `font-family: "font-bold"`) {
 		appendix += fmt.Sprintf(`<style type="text/css"><![CDATA[
@@ -140,7 +140,7 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-bold;
 	src: url("%s");
 }
-]]></style>`, d2fonts.FontEncodings.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
+]]></style>`, d2fonts.FontEncodings.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
 	}
 
 	closingIndex := strings.LastIndex(svg, "</svg></svg>")

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -121,7 +121,6 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	}
 
 	if !strings.Contains(svg, `font-family: "font-regular"`) {
-		font, _ := d2fonts.FontEncodings.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR))
 		appendix += fmt.Sprintf(`<style type="text/css"><![CDATA[
 .text {
 	font-family: "font-regular";
@@ -130,10 +129,9 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-regular;
 	src: url("%s");
 }
-]]></style>`, font.(string))
+]]></style>`, d2fonts.FontEncodings.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
 	}
 	if !strings.Contains(svg, `font-family: "font-bold"`) {
-		font, _ := d2fonts.FontEncodings.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD))
 		appendix += fmt.Sprintf(`<style type="text/css"><![CDATA[
 .text-bold {
 	font-family: "font-bold";
@@ -142,7 +140,7 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-bold;
 	src: url("%s");
 }
-]]></style>`, font.(string))
+]]></style>`, d2fonts.FontEncodings.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
 	}
 
 	closingIndex := strings.LastIndex(svg, "</svg></svg>")

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -121,6 +121,7 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	}
 
 	if !strings.Contains(svg, `font-family: "font-regular"`) {
+		font, _ := d2fonts.FontEncodings.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR))
 		appendix += fmt.Sprintf(`<style type="text/css"><![CDATA[
 .text {
 	font-family: "font-regular";
@@ -129,9 +130,10 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-regular;
 	src: url("%s");
 }
-]]></style>`, d2fonts.FontEncodings[d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)])
+]]></style>`, font.(string))
 	}
 	if !strings.Contains(svg, `font-family: "font-bold"`) {
+		font, _ := d2fonts.FontEncodings.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD))
 		appendix += fmt.Sprintf(`<style type="text/css"><![CDATA[
 .text-bold {
 	font-family: "font-bold";
@@ -140,7 +142,7 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-bold;
 	src: url("%s");
 }
-]]></style>`, d2fonts.FontEncodings[d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)])
+]]></style>`, font.(string))
 	}
 
 	closingIndex := strings.LastIndex(svg, "</svg></svg>")

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -129,7 +129,7 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-regular;
 	src: url("%s");
 }
-]]></style>`, d2fonts.FontEncodings.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+]]></style>`, d2fonts.FontEncodings.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
 	}
 	if !strings.Contains(svg, `font-family: "font-bold"`) {
 		appendix += fmt.Sprintf(`<style type="text/css"><![CDATA[
@@ -140,7 +140,7 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	font-family: font-bold;
 	src: url("%s");
 }
-]]></style>`, d2fonts.FontEncodings.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
+]]></style>`, d2fonts.FontEncodings.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
 	}
 
 	closingIndex := strings.LastIndex(svg, "</svg></svg>")

--- a/lib/pdf/pdf.go
+++ b/lib/pdf/pdf.go
@@ -31,8 +31,10 @@ func Init() *GoFPDF {
 		UnitStr: "pt",
 	})
 
-	newGofPDF.AddUTF8FontFromBytes("source", "", d2fonts.FontFaces[d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)])
-	newGofPDF.AddUTF8FontFromBytes("source", "B", d2fonts.FontFaces[d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)])
+	reg, _ := d2fonts.FontFaces.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR))
+	bold, _ := d2fonts.FontFaces.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD))
+	newGofPDF.AddUTF8FontFromBytes("source", "", reg.([]byte))
+	newGofPDF.AddUTF8FontFromBytes("source", "B", bold.([]byte))
 	newGofPDF.SetAutoPageBreak(false, 0)
 	newGofPDF.SetLineWidth(2)
 	newGofPDF.SetMargins(0, 0, 0)

--- a/lib/pdf/pdf.go
+++ b/lib/pdf/pdf.go
@@ -31,10 +31,8 @@ func Init() *GoFPDF {
 		UnitStr: "pt",
 	})
 
-	reg, _ := d2fonts.FontFaces.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR))
-	bold, _ := d2fonts.FontFaces.Load(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD))
-	newGofPDF.AddUTF8FontFromBytes("source", "", reg.([]byte))
-	newGofPDF.AddUTF8FontFromBytes("source", "B", bold.([]byte))
+	newGofPDF.AddUTF8FontFromBytes("source", "", d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+	newGofPDF.AddUTF8FontFromBytes("source", "B", d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
 	newGofPDF.SetAutoPageBreak(false, 0)
 	newGofPDF.SetLineWidth(2)
 	newGofPDF.SetMargins(0, 0, 0)

--- a/lib/pdf/pdf.go
+++ b/lib/pdf/pdf.go
@@ -31,8 +31,8 @@ func Init() *GoFPDF {
 		UnitStr: "pt",
 	})
 
-	newGofPDF.AddUTF8FontFromBytes("source", "", d2fonts.FontFaces.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
-	newGofPDF.AddUTF8FontFromBytes("source", "B", d2fonts.FontFaces.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
+	newGofPDF.AddUTF8FontFromBytes("source", "", d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+	newGofPDF.AddUTF8FontFromBytes("source", "B", d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
 	newGofPDF.SetAutoPageBreak(false, 0)
 	newGofPDF.SetLineWidth(2)
 	newGofPDF.SetMargins(0, 0, 0)

--- a/lib/pdf/pdf.go
+++ b/lib/pdf/pdf.go
@@ -31,8 +31,8 @@ func Init() *GoFPDF {
 		UnitStr: "pt",
 	})
 
-	newGofPDF.AddUTF8FontFromBytes("source", "", d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
-	newGofPDF.AddUTF8FontFromBytes("source", "B", d2fonts.FontFaces.Get(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
+	newGofPDF.AddUTF8FontFromBytes("source", "", d2fonts.FontFaces.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_REGULAR)))
+	newGofPDF.AddUTF8FontFromBytes("source", "B", d2fonts.FontFaces.MustGet(d2fonts.SourceSansPro.Font(0, d2fonts.FONT_STYLE_BOLD)))
 	newGofPDF.SetAutoPageBreak(false, 0)
 	newGofPDF.SetLineWidth(2)
 	newGofPDF.SetMargins(0, 0, 0)

--- a/lib/syncmap/syncmap.go
+++ b/lib/syncmap/syncmap.go
@@ -16,7 +16,7 @@ func (sm SyncMap[K, V]) Set(key K, value V) {
 	sm._map.Store(key, value)
 }
 
-func (sm SyncMap[K, V]) GetWithStatus(key K) (value V, ok bool) {
+func (sm SyncMap[K, V]) Get(key K) (value V, ok bool) {
 	v, has := sm._map.Load(key)
 	if !has {
 		return value, false
@@ -24,8 +24,8 @@ func (sm SyncMap[K, V]) GetWithStatus(key K) (value V, ok bool) {
 	return v.(V), true
 }
 
-func (sm SyncMap[K, V]) Get(key K) (value V) {
-	v, _ := sm.GetWithStatus(key)
+func (sm SyncMap[K, V]) MustGet(key K) (value V) {
+	v, _ := sm.Get(key)
 	return v
 }
 

--- a/lib/syncmap/syncmap.go
+++ b/lib/syncmap/syncmap.go
@@ -1,0 +1,40 @@
+package syncmap
+
+import "sync"
+
+type SyncMap[K comparable, V any] struct {
+	_map *sync.Map
+}
+
+func New[K comparable, V any]() SyncMap[K, V] {
+	return SyncMap[K, V]{
+		_map: &sync.Map{},
+	}
+}
+
+func (sm SyncMap[K, V]) Set(key K, value V) {
+	sm._map.Store(key, value)
+}
+
+func (sm SyncMap[K, V]) GetWithStatus(key K) (value V, ok bool) {
+	v, has := sm._map.Load(key)
+	if !has {
+		return value, false
+	}
+	return v.(V), true
+}
+
+func (sm SyncMap[K, V]) Get(key K) (value V) {
+	v, _ := sm.GetWithStatus(key)
+	return v
+}
+
+func (sm SyncMap[K, V]) Delete(key K) {
+	sm._map.Delete(key)
+}
+
+func (sm SyncMap[K, V]) Range(f func(key K, value V) bool) {
+	sm._map.Range(func(k, v any) bool {
+		return f(k.(K), v.(V))
+	})
+}

--- a/lib/syncmap/syncmap.go
+++ b/lib/syncmap/syncmap.go
@@ -16,7 +16,7 @@ func (sm SyncMap[K, V]) Set(key K, value V) {
 	sm._map.Store(key, value)
 }
 
-func (sm SyncMap[K, V]) Get(key K) (value V, ok bool) {
+func (sm SyncMap[K, V]) Lookup(key K) (value V, ok bool) {
 	v, has := sm._map.Load(key)
 	if !has {
 		return value, false
@@ -24,8 +24,8 @@ func (sm SyncMap[K, V]) Get(key K) (value V, ok bool) {
 	return v.(V), true
 }
 
-func (sm SyncMap[K, V]) MustGet(key K) (value V) {
-	v, _ := sm.Get(key)
+func (sm SyncMap[K, V]) Get(key K) (value V) {
+	v, _ := sm.Lookup(key)
 	return v
 }
 

--- a/lib/textmeasure/textmeasure.go
+++ b/lib/textmeasure/textmeasure.go
@@ -126,12 +126,12 @@ func NewRuler() (*Ruler, error) {
 				Style:  fontStyle,
 			}
 			// Note: FontFaces lookup is size-agnostic
-			face, has := d2fonts.FontFaces.Load(font)
+			face, has := d2fonts.FontFaces.GetWithStatus(font)
 			if !has {
 				continue
 			}
 			if _, loaded := r.ttfs[font]; !loaded {
-				ttf, err := truetype.Parse(face.([]byte))
+				ttf, err := truetype.Parse(face)
 				if err != nil {
 					return nil, err
 				}

--- a/lib/textmeasure/textmeasure.go
+++ b/lib/textmeasure/textmeasure.go
@@ -126,7 +126,7 @@ func NewRuler() (*Ruler, error) {
 				Style:  fontStyle,
 			}
 			// Note: FontFaces lookup is size-agnostic
-			face, has := d2fonts.FontFaces.Get(font)
+			face, has := d2fonts.FontFaces.Lookup(font)
 			if !has {
 				continue
 			}

--- a/lib/textmeasure/textmeasure.go
+++ b/lib/textmeasure/textmeasure.go
@@ -126,7 +126,7 @@ func NewRuler() (*Ruler, error) {
 				Style:  fontStyle,
 			}
 			// Note: FontFaces lookup is size-agnostic
-			face, has := d2fonts.FontFaces.GetWithStatus(font)
+			face, has := d2fonts.FontFaces.Get(font)
 			if !has {
 				continue
 			}

--- a/lib/textmeasure/textmeasure.go
+++ b/lib/textmeasure/textmeasure.go
@@ -126,11 +126,12 @@ func NewRuler() (*Ruler, error) {
 				Style:  fontStyle,
 			}
 			// Note: FontFaces lookup is size-agnostic
-			if _, ok := d2fonts.FontFaces[font]; !ok {
+			face, has := d2fonts.FontFaces.Load(font)
+			if !has {
 				continue
 			}
 			if _, loaded := r.ttfs[font]; !loaded {
-				ttf, err := truetype.Parse(d2fonts.FontFaces[font])
+				ttf, err := truetype.Parse(face.([]byte))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
## Summary

Updates d2fonts to not trigger races in TestCLI_E2E.

## Details
- fixes #1682 
- ran `./ci/test.sh --race ./e2etests-cli/... -count=1` 5 times successfully
- creates new SyncMap lib type as a wrapper around sync.Map