### PR TITLE
add compiler error when using arrowheads on shape

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -13,3 +13,4 @@
 - Fixes a panic with a spread substitution in a glob map [#1643](https://github.com/terrastruct/d2/pull/1643)
 - Fixes use of `null` in `sql_table` constraints (ty @landmaj) [#1660](https://github.com/terrastruct/d2/pull/1660)
 - Fixes elk growing shapes with width/height set [#1679](https://github.com/terrastruct/d2/pull/1679)
+- Adds a compiler error when accidentally using an arrowhead on a shape [#1686](https://github.com/terrastruct/d2/pull/1686)

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -284,6 +284,10 @@ func (c *compiler) compileField(obj *d2graph.Object, f *d2ir.Field) {
 		return
 	} else if f.Name == "vars" {
 		return
+	} else if f.Name == "source-arrowhead" || f.Name == "target-arrowhead" {
+		c.errorf(f.LastRef().AST(), `%#v can only be used on connections`, f.Name)
+		return
+
 	} else if isReserved {
 		c.compileReserved(&obj.Attributes, f)
 		return

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2813,6 +2813,15 @@ d2/testdata/d2compiler/TestCompile/text_no_label.d2:15:1: block string cannot be
 d2/testdata/d2compiler/TestCompile/text_no_label.d2:4:1: shape text must have a non-empty label
 d2/testdata/d2compiler/TestCompile/text_no_label.d2:7:1: shape text must have a non-empty label`,
 		},
+		{
+			name: "no_arrowheads_in_shape",
+
+			text: `x.target-arrowhead.shape: cf-one
+y.source-arrowhead.shape: cf-one
+`,
+			expErr: `d2/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.d2:1:3: "target-arrowhead" can only be used on connections
+d2/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.d2:2:3: "source-arrowhead" can only be used on connections`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.exp.json
+++ b/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.exp.json
@@ -1,0 +1,15 @@
+{
+  "graph": null,
+  "err": {
+    "errs": [
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.d2,0:2:2-0:18:18",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.d2:1:3: \"target-arrowhead\" can only be used on connections"
+      },
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.d2,1:2:35-1:18:51",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/no_arrowheads_in_shape.d2:2:3: \"source-arrowhead\" can only be used on connections"
+      }
+    ]
+  }
+}


### PR DESCRIPTION

## Summary

Adds a compiler error when using `source-arrowhead` or `target-arrowhead` on a shape instead of a connection.

## Details 
- fixes #1685 
- adds no_arrowheads_in_shape compiler test

