### PR TITLE
cli: Add flag --png-scale to control PNG resolution

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -1,6 +1,7 @@
 #### Features 🚀
 
 - ELK now routes `sql_table` edges to the exact columns (ty @landmaj) [#1681](https://github.com/terrastruct/d2/pull/1681)
+- CLI now supports `--png-scale` flag to scale the output PNG. [#1701](https://github.com/terrastruct/d2/pull/1701)
 
 #### Improvements 🧹
 

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -56,6 +56,7 @@ type watcherOpts struct {
 	forceAppendix   bool
 	pw              png.Playwright
 	fontFamily      *d2fonts.FontFamily
+	pngScale        int64
 }
 
 type watcher struct {
@@ -364,7 +365,7 @@ func (w *watcher) compileLoop(ctx context.Context) error {
 			w.pw = newPW
 		}
 
-		svg, _, err := compile(ctx, w.ms, w.plugins, w.layout, w.renderOpts, w.fontFamily, w.animateInterval, w.inputPath, w.outputPath, w.boardPath, w.bundle, w.forceAppendix, w.pw.Page)
+		svg, _, err := compile(ctx, w.ms, w.plugins, w.layout, w.renderOpts, w.fontFamily, w.animateInterval, w.inputPath, w.outputPath, w.boardPath, w.bundle, w.forceAppendix, w.pw.Page, w.pngScale)
 		errs := ""
 		if err != nil {
 			if len(svg) > 0 {

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -40,6 +40,17 @@ func TestCLI_E2E(t *testing.T) {
 			},
 		},
 		{
+			name:   "hello_world_png_scale",
+			skipCI: true,
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "hello-world.d2", `x -> y`)
+				err := runTestMain(t, ctx, dir, env, "--png-scale=2", "hello-world.d2", "hello-world.png")
+				assert.Success(t, err)
+				png := readFile(t, dir, "hello-world.png")
+				testdataIgnoreDiff(t, ".png", png)
+			},
+		},
+		{
 			name:   "hello_world_png_pad",
 			skipCI: true,
 			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -16,8 +16,7 @@ import (
 	"oss.terrastruct.com/d2/lib/version"
 )
 
-// ConvertSVG scales the image by 2x
-const SCALE = 2.
+const DEFAULT_PNG_SCALE = 2
 
 type Playwright struct {
 	PW      *playwright.Playwright
@@ -85,11 +84,11 @@ const pngPrefix = "data:image/png;base64,"
 
 // ConvertSVG converts the given SVG into a PNG.
 // Note that the resulting PNG has 2x the size (width and height) of the original SVG (see generate_png.js)
-func ConvertSVG(page playwright.Page, svg []byte) ([]byte, error) {
+func ConvertSVG(page playwright.Page, svg []byte, pngScale int64) ([]byte, error) {
 	encodedSVG := base64.StdEncoding.EncodeToString(svg)
 	pngInterface, err := page.Evaluate(genPNGScript, map[string]interface{}{
 		"imgString": "data:image/svg+xml;charset=utf-8;base64," + encodedSVG,
-		"scale":     int(SCALE),
+		"scale":     int(pngScale),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate png: %w", err)

--- a/lib/png/png.go
+++ b/lib/png/png.go
@@ -83,7 +83,6 @@ var genPNGScript string
 const pngPrefix = "data:image/png;base64,"
 
 // ConvertSVG converts the given SVG into a PNG.
-// Note that the resulting PNG has 2x the size (width and height) of the original SVG (see generate_png.js)
 func ConvertSVG(page playwright.Page, svg []byte, pngScale int64) ([]byte, error) {
 	encodedSVG := base64.StdEncoding.EncodeToString(svg)
 	pngInterface, err := page.Evaluate(genPNGScript, map[string]interface{}{


### PR DESCRIPTION
#463

# PNG Export Results

`./main input.d2 output-1x.png --png-scale=1`

![output-1x](https://github.com/terrastruct/d2/assets/56968475/5dfb27df-5c0a-47e9-a6a3-1884124a20e9)

`./main input.d2 output-2x.png --png-scale=2`

![output-2x](https://github.com/terrastruct/d2/assets/56968475/390cbd38-25f0-4f32-8ef1-fcd0e727795c)

`./main input.d2 output-4x.png --png-scale=4`

![output-4x](https://github.com/terrastruct/d2/assets/56968475/68efdd07-a5bf-4ecd-87a5-d8ee078a33ec)

# CLI Usage Output

```
./main 
main v0.6.1-HEAD
Usage:
  main [--watch=false] [--theme=0] file.d2 [file.svg | file.png]
  main layout [name]
  main fmt file.d2 ...

main compiles and renders file.d2 to file.svg | file.png
It defaults to file.svg if an output path is not provided.

Use - to have d2 read from stdin or write to stdout.

See man d2 for more detailed docs.

Flags:
  -w, --watch                  $D2_WATCH             watch for changes to input and live reload. Use $HOST and $PORT to specify the listening address.
                                                     (default localhost:0, which is will open on a randomly available local port). (default false)
  -h, --host string            $HOST                 host listening address when used with watch (default "localhost")
  -p, --port string            $PORT                 port listening address when used with watch (default "0")
  -b, --bundle                 $D2_BUNDLE            when outputting SVG, bundle all assets and layers into the output file (default true)
      --force-appendix         $D2_FORCE_APPENDIX    an appendix for tooltips and links is added to PNG exports since they are not interactive. --force-appendix adds an appendix to SVG exports as well (default false)
  -d, --debug                  $DEBUG                print debug logs. (default false)
      --img-cache              $IMG_CACHE            in watch mode, images used in icons are cached for subsequent compilations. This should be disabled if images might change. (default true)
  -l, --layout string          $D2_LAYOUT            the layout engine used (default "dagre")
  -t, --theme int              $D2_THEME             the diagram theme ID (default 0)
      --dark-theme int         $D2_DARK_THEME        the theme to use when the viewer's browser is in dark mode. When left unset -theme is used for both light and dark mode. Be aware that explicit styles set in D2 code will still be applied and this may produce unexpected results. W
e plan on resolving this by making style maps in D2 light/dark mode specific. See https://github.com/terrastruct/d2/issues/831. (default -1)                                                                                                                                                     --pad int                $D2_PAD               pixels padded around the rendered diagram (default 100)
      --animate-interval int   $D2_ANIMATE_INTERVAL  if given, multiple boards are packaged as 1 SVG which transitions through each board at the interval (in milliseconds). Can only be used with SVG exports. (default 0)
      --timeout int            $D2_TIMEOUT           the maximum number of seconds that D2 runs for before timing out and exiting. When rendering a large diagram, it is recommended to increase this value (default 120)
  -v, --version                                      get the version (default false)
  -s, --sketch                 $D2_SKETCH            render the diagram to look like it was sketched by hand (default false)
      --browser string         $BROWSER              browser executable that watch opens. Setting to 0 opens no browser. (default "")
  -c, --center                 $D2_CENTER            center the SVG in the containing viewbox, such as your browser screen (default false)
      --scale float            $SCALE                scale the output. E.g., 0.5 to halve the default size. Default -1 means that SVG's will fit to screen and all others will use their default render size. Setting to 1 turns off SVG fitting to screen. (default -1)
      --png-scale int          $PNG_SCALE            scale the output PNG. E.g., 2 to double the default size. Default 2 means that PNG's will be twice as big as SVG's. Setting to 1 turns off PNG scaling. (default 2)
      --font-regular string    $D2_FONT_REGULAR      path to .ttf file to use for the regular font. If none provided, Source Sans Pro Regular is used. (default "")
      --font-italic string     $D2_FONT_ITALIC       path to .ttf file to use for the italic font. If none provided, Source Sans Pro Regular-Italic is used. (default "")
      --font-bold string       $D2_FONT_BOLD         path to .ttf file to use for the bold font. If none provided, Source Sans Pro Bold is used. (default "")
      --font-semibold string   $D2_FONT_SEMIBOLD     path to .ttf file to use for the semibold font. If none provided, Source Sans Pro Semibold is used. (default "")


Subcommands:
  main layout - Lists available layout engine options with short help
  main layout [name] - Display long help for a particular layout engine, including its configuration options
  main themes - Lists available themes
  main fmt file.d2 ... - Format passed files

See more docs and the source code at https://oss.terrastruct.com/d2.
Hosted icons at https://icons.terrastruct.com.
Playground runner at https://play.d2lang.com.
```