### PR TITLE
fix appendix icon numbering/order

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -19,3 +19,4 @@
 - Adds a compiler error when accidentally using an arrowhead on a shape [#1686](https://github.com/terrastruct/d2/pull/1686)
 - Correctly reports errors from invalid values set by globs. [#1691](https://github.com/terrastruct/d2/pull/1691)
 - Fixes panic when spread substitution referenced a nonexistant var. [#1695](https://github.com/terrastruct/d2/pull/1695)
+- Fixes incorrect appendix icon numbering. [#1704](https://github.com/terrastruct/d2/pull/1704)

--- a/d2renderers/d2svg/appendix/appendix.go
+++ b/d2renderers/d2svg/appendix/appendix.go
@@ -7,6 +7,7 @@ package appendix
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -146,18 +147,47 @@ func Append(diagram *d2target.Diagram, ruler *textmeasure.Ruler, in []byte) []by
 	closingIndex := strings.LastIndex(svg, "</svg></svg>")
 	svg = svg[:closingIndex] + appendix + svg[closingIndex:]
 
+	// icons are numbered according to diagram.Shapes which is based on their order of definition,
+	// but they appear in the svg according to renderOrder so we have to replace in that order
+	type appendixIcon struct {
+		number    int
+		isTooltip bool
+		shape     d2target.Shape
+	}
+	var renderOrder []appendixIcon
+
 	i := 1
 	for _, s := range diagram.Shapes {
 		if s.Tooltip != "" {
-			// The clip-path has a unique ID, so this won't replace any user icons
-			// In the existing SVG, the transform places it top-left, so we adjust
-			svg = strings.Replace(svg, d2svg.TooltipIcon, generateNumberedIcon(i, 0, ICON_RADIUS), 1)
+			renderOrder = append(renderOrder, appendixIcon{i, true, s})
 			i++
 		}
 		if s.Link != "" {
-			svg = strings.Replace(svg, d2svg.LinkIcon, generateNumberedIcon(i, 0, ICON_RADIUS), 1)
+			renderOrder = append(renderOrder, appendixIcon{i, false, s})
 			i++
 		}
+	}
+	// sort to match render order
+	sort.SliceStable(renderOrder, func(i, j int) bool {
+		iZIndex := renderOrder[i].shape.GetZIndex()
+		jZIndex := renderOrder[j].shape.GetZIndex()
+		if iZIndex != jZIndex {
+			return iZIndex < jZIndex
+		}
+		return renderOrder[i].shape.Level < renderOrder[j].shape.Level
+	})
+
+	// replace each rendered svg icon
+	for _, icon := range renderOrder {
+		// The clip-path has a unique ID, so this won't replace any user icons
+		// In the existing SVG, the transform places it top-left, so we adjust
+		var iconStr string
+		if icon.isTooltip {
+			iconStr = d2svg.TooltipIcon
+		} else {
+			iconStr = d2svg.LinkIcon
+		}
+		svg = strings.Replace(svg, iconStr, generateNumberedIcon(icon.number, 0, ICON_RADIUS), 1)
 	}
 
 	return []byte(svg)


### PR DESCRIPTION
## Summary

Fixes incorrect appendix icon numbering.

## Details
- fixes #1703 
- appendix tooltip/link icons used to be replaced in the svg according to their numbered order, but the icons in the svg are ordered according to the render order
- fixes appendix creation to replace each rendered icon with the correct number icon

### example from #1703 
X is defined first so X should get 1 and Y 2, but X is rendered after Y and all the other 1st level shapes because it has to appear in front of its parent container.
Previously this meant the 1st icon in the svg was Y's icon which was incorrectly replaced with a 1 icon.

```d2
Block: {
  X: {tooltip: X}
}
Y: {tooltip: Y}
```

### before
<img width="765" alt="Screenshot 2023-11-06 at 4 36 28 PM" src="https://github.com/terrastruct/d2/assets/85081687/a40d0abd-622e-48b8-8cd5-202255d121cd">

### after
<img width="733" alt="Screenshot 2023-11-06 at 4 36 35 PM" src="https://github.com/terrastruct/d2/assets/85081687/593adaf2-0bc6-41cd-89ff-29064f79e268">

