### PR TITLE
cli: override log output from d2cli only

### DIFF
--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -1245,3 +1245,7 @@ func AnimatePNGs(ms *xmain.State, pngs [][]byte, animIntervalMs int) ([]byte, er
 
 	return xgif.AnimatePNGs(pngs, animIntervalMs)
 }
+
+func init() {
+	ctxlog.Init()
+}

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -18,7 +18,7 @@ import (
 
 var _default = slog.Make(sloghuman.Sink(os.Stderr)).Named("default")
 
-func init() {
+func Init() {
 	stdlib := slog.Stdlib(context.Background(), _default, slog.LevelInfo)
 	log.SetOutput(stdlib.Writer())
 }


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

This PR changes lib/log and d2cli so that the built-in log output is overridden only from d2cli only. Other use of the package lib/log will leave the built-in log output unchanged.

Closes #1680
