### PR TITLE
allow plugins to route cross-graph edges

### DIFF
--- a/d2exporter/export_test.go
+++ b/d2exporter/export_test.go
@@ -235,7 +235,7 @@ func run(t *testing.T, tc testCase) {
 	assert.JSON(t, nil, err)
 
 	graphInfo := d2layouts.NestedGraphInfo(g.Root)
-	err = d2layouts.LayoutNested(ctx, g, graphInfo, d2dagrelayout.DefaultLayout)
+	err = d2layouts.LayoutNested(ctx, g, graphInfo, d2dagrelayout.DefaultLayout, d2layouts.DefaultRouter)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/d2graph/d2graph.go
+++ b/d2graph/d2graph.go
@@ -80,6 +80,7 @@ func (g *Graph) RootBoard() *Graph {
 }
 
 type LayoutGraph func(context.Context, *Graph) error
+type RouteEdges func(context.Context, *Graph, []*Edge) error
 
 // TODO consider having different Scalar types
 // Right now we'll hold any types in Value and just convert, e.g. floats

--- a/d2plugin/plugin.go
+++ b/d2plugin/plugin.go
@@ -80,6 +80,11 @@ type Plugin interface {
 	PostProcess(context.Context, []byte) ([]byte, error)
 }
 
+type RoutingPlugin interface {
+	// RouteEdges runs the plugin's edge routing algorithm for the given edges in the input graph
+	RouteEdges(context.Context, *d2graph.Graph, []*d2graph.Edge) error
+}
+
 // PluginInfo is the current info information of a plugin.
 // note: The two fields Type and Path are not set by the plugin
 // itself but only in ListPlugins.

--- a/d2plugin/plugin_features.go
+++ b/d2plugin/plugin_features.go
@@ -21,6 +21,9 @@ const TOP_LEFT PluginFeature = "top_left"
 // When this is true, containers can have connections to descendants
 const DESCENDANT_EDGES PluginFeature = "descendant_edges"
 
+// When this is true, the plugin also implements RoutingPlugin interface to route edges
+const ROUTES_EDGES PluginFeature = "routes_edges"
+
 func FeatureSupportCheck(info *PluginInfo, g *d2graph.Graph) error {
 	// Older version of plugin. Skip checking.
 	if info.Features == nil {


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
## Summary

Allows plugins to route cross-graph edges.

## Details
- If a plugin has the `ROUTES_EDGES` plugin feature and implements the `RoutingPlugin` interface, then it will be used for edge routing across graphs
- https://github.com/terrastruct/TALA/issues/63