### PR TITLE
Fix render target containing "index"

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -5,4 +5,5 @@
 #### Bugfixes ⛑️
 
 - Fix importing files that override an existing value with an array. [#1762](https://github.com/terrastruct/d2/pull/1762)
-- Fixed missing unfilled triangle arrowheads when sketch flag is on. [#1763](https://github.com/terrastruct/d2/pull/1763)
+- Fixes missing unfilled triangle arrowheads when sketch flag is on. [#1763](https://github.com/terrastruct/d2/pull/1763)
+- Fixes a bug where the render target could be incorrect if the target path contains "index". [#1764](https://github.com/terrastruct/d2/pull/1764)

--- a/d2target/d2target.go
+++ b/d2target/d2target.go
@@ -79,7 +79,7 @@ func (d *Diagram) GetBoard(boardPath []string) *Diagram {
 
 	head := boardPath[0]
 
-	if head == "index" {
+	if len(boardPath) == 1 && d.Name == head {
 		return d
 	}
 

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -300,6 +300,56 @@ scenarios: {
 			},
 		},
 		{
+			name: "target-nested-index",
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "target-nested-index.d2", `a
+layers: {
+	l1: {
+		b
+		layers: {
+			index: {
+				c
+				layers: {
+					l3: {
+						d
+					}
+				}
+			}
+		}
+	}
+}`)
+				err := runTestMain(t, ctx, dir, env, "--target", `l1.index.l3`, "target-nested-index.d2", "target-nested-index.svg")
+				assert.Success(t, err)
+				svg := readFile(t, dir, "target-nested-index.svg")
+				assert.Testdata(t, ".svg", svg)
+			},
+		},
+		{
+			name: "target-nested-index2",
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "target-nested-index2.d2", `a
+layers: {
+	index: {
+		b
+		layers: {
+			nest1: {
+				c
+				scenarios: {
+					nest2: {
+						d
+					}
+				}
+			}
+		}
+	}
+}`)
+				err := runTestMain(t, ctx, dir, env, "--target", `index.nest1.nest2`, "target-nested-index2.d2", "target-nested-index2.svg")
+				assert.Success(t, err)
+				svg := readFile(t, dir, "target-nested-index2.svg")
+				assert.Testdata(t, ".svg", svg)
+			},
+		},
+		{
 			name: "multiboard/life",
 			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
 				writeFile(t, dir, "life.d2", `x -> y

--- a/e2etests-cli/testdata/TestCLI_E2E/target-nested-index.exp.svg
+++ b/e2etests-cli/testdata/TestCLI_E2E/target-nested-index.exp.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" d2Version="v0.6.2-HEAD" preserveAspectRatio="xMinYMin meet" viewBox="0 0 255 268"><svg id="d2-svg" class="d2-2469949388" width="255" height="268" viewBox="-101 -101 255 268"><rect x="-101.000000" y="-101.000000" width="255.000000" height="268.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-2469949388 .text-bold {
+	font-family: "d2-2469949388-font-bold";
+}
+@font-face {
+	font-family: d2-2469949388-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAAYUAAoAAAAACtAAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAMAAAADAADQCZZ2x5ZgAAAYQAAAC8AAAAvDgVdotoZWFkAAACQAAAADYAAAA2G38e1GhoZWEAAAJ4AAAAJAAAACQKfwXBaG10eAAAApwAAAAIAAAACATvAJFsb2NhAAACpAAAAAYAAAAGAF4ALG1heHAAAAKsAAAAIAAAACAAGgD3bmFtZQAAAswAAAMoAAAIKgjwVkFwb3N0AAAF9AAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAAwAAAAEAAwABAAAADAAEACQAAAAEAAQAAQAAAGL//wAAAGL///+fAAEAAAAAAAEAAAAFAFAAAAJiApQAAwAJAA8AEgAVAAAzESERJTMnJyMHNzM3NyMXAzcnAREHUAIS/qWkJykEKSkEKiCYH3pfXwFNXgKU/WxbTWJi9l87O/6eubr+jQFzugAAAgBB//QCFgK9ABQAHwAABSImJyMHIxEzFQc2NjMyFhYVFAYGJzI2NTQjIgcVFhYBRSFDHQQMc5MEHUQiPFgvPF9YJjZWLCkUKAwhIDUCvaxMGh0+cUxVeT94RkyGLcsSDgAAAAEAAAACC4UO4vCNXw889QABA+gAAAAA2F2ghAAAAADdZi82/jf+xAhtA/EAAQADAAIAAAAAAAAAAQAAA9j+7wAACJj+N/43CG0AAQAAAAAAAAAAAAAAAAAAAAICsgBQAj0AQQAAACwAXgAAAAEAAAACAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
+}]]></style><style type="text/css"><![CDATA[.shape {
+  shape-rendering: geometricPrecision;
+  stroke-linejoin: round;
+}
+.connection {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.blend {
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+
+		.d2-2469949388 .fill-N1{fill:#0A0F25;}
+		.d2-2469949388 .fill-N2{fill:#676C7E;}
+		.d2-2469949388 .fill-N3{fill:#9499AB;}
+		.d2-2469949388 .fill-N4{fill:#CFD2DD;}
+		.d2-2469949388 .fill-N5{fill:#DEE1EB;}
+		.d2-2469949388 .fill-N6{fill:#EEF1F8;}
+		.d2-2469949388 .fill-N7{fill:#FFFFFF;}
+		.d2-2469949388 .fill-B1{fill:#0D32B2;}
+		.d2-2469949388 .fill-B2{fill:#0D32B2;}
+		.d2-2469949388 .fill-B3{fill:#E3E9FD;}
+		.d2-2469949388 .fill-B4{fill:#E3E9FD;}
+		.d2-2469949388 .fill-B5{fill:#EDF0FD;}
+		.d2-2469949388 .fill-B6{fill:#F7F8FE;}
+		.d2-2469949388 .fill-AA2{fill:#4A6FF3;}
+		.d2-2469949388 .fill-AA4{fill:#EDF0FD;}
+		.d2-2469949388 .fill-AA5{fill:#F7F8FE;}
+		.d2-2469949388 .fill-AB4{fill:#EDF0FD;}
+		.d2-2469949388 .fill-AB5{fill:#F7F8FE;}
+		.d2-2469949388 .stroke-N1{stroke:#0A0F25;}
+		.d2-2469949388 .stroke-N2{stroke:#676C7E;}
+		.d2-2469949388 .stroke-N3{stroke:#9499AB;}
+		.d2-2469949388 .stroke-N4{stroke:#CFD2DD;}
+		.d2-2469949388 .stroke-N5{stroke:#DEE1EB;}
+		.d2-2469949388 .stroke-N6{stroke:#EEF1F8;}
+		.d2-2469949388 .stroke-N7{stroke:#FFFFFF;}
+		.d2-2469949388 .stroke-B1{stroke:#0D32B2;}
+		.d2-2469949388 .stroke-B2{stroke:#0D32B2;}
+		.d2-2469949388 .stroke-B3{stroke:#E3E9FD;}
+		.d2-2469949388 .stroke-B4{stroke:#E3E9FD;}
+		.d2-2469949388 .stroke-B5{stroke:#EDF0FD;}
+		.d2-2469949388 .stroke-B6{stroke:#F7F8FE;}
+		.d2-2469949388 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-2469949388 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-2469949388 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-2469949388 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-2469949388 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-2469949388 .background-color-N1{background-color:#0A0F25;}
+		.d2-2469949388 .background-color-N2{background-color:#676C7E;}
+		.d2-2469949388 .background-color-N3{background-color:#9499AB;}
+		.d2-2469949388 .background-color-N4{background-color:#CFD2DD;}
+		.d2-2469949388 .background-color-N5{background-color:#DEE1EB;}
+		.d2-2469949388 .background-color-N6{background-color:#EEF1F8;}
+		.d2-2469949388 .background-color-N7{background-color:#FFFFFF;}
+		.d2-2469949388 .background-color-B1{background-color:#0D32B2;}
+		.d2-2469949388 .background-color-B2{background-color:#0D32B2;}
+		.d2-2469949388 .background-color-B3{background-color:#E3E9FD;}
+		.d2-2469949388 .background-color-B4{background-color:#E3E9FD;}
+		.d2-2469949388 .background-color-B5{background-color:#EDF0FD;}
+		.d2-2469949388 .background-color-B6{background-color:#F7F8FE;}
+		.d2-2469949388 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-2469949388 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-2469949388 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-2469949388 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-2469949388 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-2469949388 .color-N1{color:#0A0F25;}
+		.d2-2469949388 .color-N2{color:#676C7E;}
+		.d2-2469949388 .color-N3{color:#9499AB;}
+		.d2-2469949388 .color-N4{color:#CFD2DD;}
+		.d2-2469949388 .color-N5{color:#DEE1EB;}
+		.d2-2469949388 .color-N6{color:#EEF1F8;}
+		.d2-2469949388 .color-N7{color:#FFFFFF;}
+		.d2-2469949388 .color-B1{color:#0D32B2;}
+		.d2-2469949388 .color-B2{color:#0D32B2;}
+		.d2-2469949388 .color-B3{color:#E3E9FD;}
+		.d2-2469949388 .color-B4{color:#E3E9FD;}
+		.d2-2469949388 .color-B5{color:#EDF0FD;}
+		.d2-2469949388 .color-B6{color:#F7F8FE;}
+		.d2-2469949388 .color-AA2{color:#4A6FF3;}
+		.d2-2469949388 .color-AA4{color:#EDF0FD;}
+		.d2-2469949388 .color-AA5{color:#F7F8FE;}
+		.d2-2469949388 .color-AB4{color:#EDF0FD;}
+		.d2-2469949388 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><g id="b"><g class="shape" ><rect x="0.000000" y="0.000000" width="53.000000" height="66.000000" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="26.500000" y="38.500000" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">b</text></g><mask id="d2-2469949388" maskUnits="userSpaceOnUse" x="-101" y="-101" width="255" height="268">
+<rect x="-101" y="-101" width="255" height="268" fill="white"></rect>
+<rect x="22.500000" y="22.500000" width="8" height="21" fill="rgba(0,0,0,0.75)"></rect>
+</mask></svg></svg>

--- a/e2etests-cli/testdata/TestCLI_E2E/target-nested-index.exp.svg
+++ b/e2etests-cli/testdata/TestCLI_E2E/target-nested-index.exp.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" d2Version="v0.6.2-HEAD" preserveAspectRatio="xMinYMin meet" viewBox="0 0 255 268"><svg id="d2-svg" class="d2-2469949388" width="255" height="268" viewBox="-101 -101 255 268"><rect x="-101.000000" y="-101.000000" width="255.000000" height="268.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
-.d2-2469949388 .text-bold {
-	font-family: "d2-2469949388-font-bold";
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" d2Version="v0.6.2-HEAD" preserveAspectRatio="xMinYMin meet" viewBox="0 0 256 268"><svg id="d2-svg" class="d2-2306023678" width="256" height="268" viewBox="-101 -101 256 268"><rect x="-101.000000" y="-101.000000" width="256.000000" height="268.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-2306023678 .text-bold {
+	font-family: "d2-2306023678-font-bold";
 }
 @font-face {
-	font-family: d2-2469949388-font-bold;
-	src: url("data:application/font-woff;base64,d09GRgABAAAAAAYUAAoAAAAACtAAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAMAAAADAADQCZZ2x5ZgAAAYQAAAC8AAAAvDgVdotoZWFkAAACQAAAADYAAAA2G38e1GhoZWEAAAJ4AAAAJAAAACQKfwXBaG10eAAAApwAAAAIAAAACATvAJFsb2NhAAACpAAAAAYAAAAGAF4ALG1heHAAAAKsAAAAIAAAACAAGgD3bmFtZQAAAswAAAMoAAAIKgjwVkFwb3N0AAAF9AAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAAwAAAAEAAwABAAAADAAEACQAAAAEAAQAAQAAAGL//wAAAGL///+fAAEAAAAAAAEAAAAFAFAAAAJiApQAAwAJAA8AEgAVAAAzESERJTMnJyMHNzM3NyMXAzcnAREHUAIS/qWkJykEKSkEKiCYH3pfXwFNXgKU/WxbTWJi9l87O/6eubr+jQFzugAAAgBB//QCFgK9ABQAHwAABSImJyMHIxEzFQc2NjMyFhYVFAYGJzI2NTQjIgcVFhYBRSFDHQQMc5MEHUQiPFgvPF9YJjZWLCkUKAwhIDUCvaxMGh0+cUxVeT94RkyGLcsSDgAAAAEAAAACC4UO4vCNXw889QABA+gAAAAA2F2ghAAAAADdZi82/jf+xAhtA/EAAQADAAIAAAAAAAAAAQAAA9j+7wAACJj+N/43CG0AAQAAAAAAAAAAAAAAAAAAAAICsgBQAj0AQQAAACwAXgAAAAEAAAACAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
+	font-family: d2-2306023678-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAAYUAAoAAAAACtAAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAMAAAADAADQCbZ2x5ZgAAAYQAAAC8AAAAvOGdu5BoZWFkAAACQAAAADYAAAA2G38e1GhoZWEAAAJ4AAAAJAAAACQKfwXBaG10eAAAApwAAAAIAAAACATvAHdsb2NhAAACpAAAAAYAAAAGAF4ALG1heHAAAAKsAAAAIAAAACAAGgD3bmFtZQAAAswAAAMoAAAIKgjwVkFwb3N0AAAF9AAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAAwAAAAEAAwABAAAADAAEACQAAAAEAAQAAQAAAGT//wAAAGT///+dAAEAAAAAAAEAAAAFAFAAAAJiApQAAwAJAA8AEgAVAAAzESERJTMnJyMHNzM3NyMXAzcnAREHUAIS/qWkJykEKSkEKiCYH3pfXwFNXgKU/WxbTWJi9l87O/6eubr+jQFzugAAAgAn//QB/AK9ABMAIAAAFyImNTQ2NjMyFhcnNTMRIycjBgY3MjY3NSYmIyIGFRQW8lxvO180KTgZBpN4CgQaRgIYJxITKxQjNi8Mi3lRdT4cGEyp/UMxGiN4FBnLEg5DR0lFAAEAAAACC4W70mazXw889QABA+gAAAAA2F2ghAAAAADdZi82/jf+xAhtA/EAAQADAAIAAAAAAAAAAQAAA9j+7wAACJj+N/43CG0AAQAAAAAAAAAAAAAAAAAAAAICsgBQAj0AJwAAACwAXgAAAAEAAAACAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
 }]]></style><style type="text/css"><![CDATA[.shape {
   shape-rendering: geometricPrecision;
   stroke-linejoin: round;
@@ -18,78 +18,78 @@
   opacity: 0.5;
 }
 
-		.d2-2469949388 .fill-N1{fill:#0A0F25;}
-		.d2-2469949388 .fill-N2{fill:#676C7E;}
-		.d2-2469949388 .fill-N3{fill:#9499AB;}
-		.d2-2469949388 .fill-N4{fill:#CFD2DD;}
-		.d2-2469949388 .fill-N5{fill:#DEE1EB;}
-		.d2-2469949388 .fill-N6{fill:#EEF1F8;}
-		.d2-2469949388 .fill-N7{fill:#FFFFFF;}
-		.d2-2469949388 .fill-B1{fill:#0D32B2;}
-		.d2-2469949388 .fill-B2{fill:#0D32B2;}
-		.d2-2469949388 .fill-B3{fill:#E3E9FD;}
-		.d2-2469949388 .fill-B4{fill:#E3E9FD;}
-		.d2-2469949388 .fill-B5{fill:#EDF0FD;}
-		.d2-2469949388 .fill-B6{fill:#F7F8FE;}
-		.d2-2469949388 .fill-AA2{fill:#4A6FF3;}
-		.d2-2469949388 .fill-AA4{fill:#EDF0FD;}
-		.d2-2469949388 .fill-AA5{fill:#F7F8FE;}
-		.d2-2469949388 .fill-AB4{fill:#EDF0FD;}
-		.d2-2469949388 .fill-AB5{fill:#F7F8FE;}
-		.d2-2469949388 .stroke-N1{stroke:#0A0F25;}
-		.d2-2469949388 .stroke-N2{stroke:#676C7E;}
-		.d2-2469949388 .stroke-N3{stroke:#9499AB;}
-		.d2-2469949388 .stroke-N4{stroke:#CFD2DD;}
-		.d2-2469949388 .stroke-N5{stroke:#DEE1EB;}
-		.d2-2469949388 .stroke-N6{stroke:#EEF1F8;}
-		.d2-2469949388 .stroke-N7{stroke:#FFFFFF;}
-		.d2-2469949388 .stroke-B1{stroke:#0D32B2;}
-		.d2-2469949388 .stroke-B2{stroke:#0D32B2;}
-		.d2-2469949388 .stroke-B3{stroke:#E3E9FD;}
-		.d2-2469949388 .stroke-B4{stroke:#E3E9FD;}
-		.d2-2469949388 .stroke-B5{stroke:#EDF0FD;}
-		.d2-2469949388 .stroke-B6{stroke:#F7F8FE;}
-		.d2-2469949388 .stroke-AA2{stroke:#4A6FF3;}
-		.d2-2469949388 .stroke-AA4{stroke:#EDF0FD;}
-		.d2-2469949388 .stroke-AA5{stroke:#F7F8FE;}
-		.d2-2469949388 .stroke-AB4{stroke:#EDF0FD;}
-		.d2-2469949388 .stroke-AB5{stroke:#F7F8FE;}
-		.d2-2469949388 .background-color-N1{background-color:#0A0F25;}
-		.d2-2469949388 .background-color-N2{background-color:#676C7E;}
-		.d2-2469949388 .background-color-N3{background-color:#9499AB;}
-		.d2-2469949388 .background-color-N4{background-color:#CFD2DD;}
-		.d2-2469949388 .background-color-N5{background-color:#DEE1EB;}
-		.d2-2469949388 .background-color-N6{background-color:#EEF1F8;}
-		.d2-2469949388 .background-color-N7{background-color:#FFFFFF;}
-		.d2-2469949388 .background-color-B1{background-color:#0D32B2;}
-		.d2-2469949388 .background-color-B2{background-color:#0D32B2;}
-		.d2-2469949388 .background-color-B3{background-color:#E3E9FD;}
-		.d2-2469949388 .background-color-B4{background-color:#E3E9FD;}
-		.d2-2469949388 .background-color-B5{background-color:#EDF0FD;}
-		.d2-2469949388 .background-color-B6{background-color:#F7F8FE;}
-		.d2-2469949388 .background-color-AA2{background-color:#4A6FF3;}
-		.d2-2469949388 .background-color-AA4{background-color:#EDF0FD;}
-		.d2-2469949388 .background-color-AA5{background-color:#F7F8FE;}
-		.d2-2469949388 .background-color-AB4{background-color:#EDF0FD;}
-		.d2-2469949388 .background-color-AB5{background-color:#F7F8FE;}
-		.d2-2469949388 .color-N1{color:#0A0F25;}
-		.d2-2469949388 .color-N2{color:#676C7E;}
-		.d2-2469949388 .color-N3{color:#9499AB;}
-		.d2-2469949388 .color-N4{color:#CFD2DD;}
-		.d2-2469949388 .color-N5{color:#DEE1EB;}
-		.d2-2469949388 .color-N6{color:#EEF1F8;}
-		.d2-2469949388 .color-N7{color:#FFFFFF;}
-		.d2-2469949388 .color-B1{color:#0D32B2;}
-		.d2-2469949388 .color-B2{color:#0D32B2;}
-		.d2-2469949388 .color-B3{color:#E3E9FD;}
-		.d2-2469949388 .color-B4{color:#E3E9FD;}
-		.d2-2469949388 .color-B5{color:#EDF0FD;}
-		.d2-2469949388 .color-B6{color:#F7F8FE;}
-		.d2-2469949388 .color-AA2{color:#4A6FF3;}
-		.d2-2469949388 .color-AA4{color:#EDF0FD;}
-		.d2-2469949388 .color-AA5{color:#F7F8FE;}
-		.d2-2469949388 .color-AB4{color:#EDF0FD;}
-		.d2-2469949388 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><g id="b"><g class="shape" ><rect x="0.000000" y="0.000000" width="53.000000" height="66.000000" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="26.500000" y="38.500000" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">b</text></g><mask id="d2-2469949388" maskUnits="userSpaceOnUse" x="-101" y="-101" width="255" height="268">
-<rect x="-101" y="-101" width="255" height="268" fill="white"></rect>
-<rect x="22.500000" y="22.500000" width="8" height="21" fill="rgba(0,0,0,0.75)"></rect>
+		.d2-2306023678 .fill-N1{fill:#0A0F25;}
+		.d2-2306023678 .fill-N2{fill:#676C7E;}
+		.d2-2306023678 .fill-N3{fill:#9499AB;}
+		.d2-2306023678 .fill-N4{fill:#CFD2DD;}
+		.d2-2306023678 .fill-N5{fill:#DEE1EB;}
+		.d2-2306023678 .fill-N6{fill:#EEF1F8;}
+		.d2-2306023678 .fill-N7{fill:#FFFFFF;}
+		.d2-2306023678 .fill-B1{fill:#0D32B2;}
+		.d2-2306023678 .fill-B2{fill:#0D32B2;}
+		.d2-2306023678 .fill-B3{fill:#E3E9FD;}
+		.d2-2306023678 .fill-B4{fill:#E3E9FD;}
+		.d2-2306023678 .fill-B5{fill:#EDF0FD;}
+		.d2-2306023678 .fill-B6{fill:#F7F8FE;}
+		.d2-2306023678 .fill-AA2{fill:#4A6FF3;}
+		.d2-2306023678 .fill-AA4{fill:#EDF0FD;}
+		.d2-2306023678 .fill-AA5{fill:#F7F8FE;}
+		.d2-2306023678 .fill-AB4{fill:#EDF0FD;}
+		.d2-2306023678 .fill-AB5{fill:#F7F8FE;}
+		.d2-2306023678 .stroke-N1{stroke:#0A0F25;}
+		.d2-2306023678 .stroke-N2{stroke:#676C7E;}
+		.d2-2306023678 .stroke-N3{stroke:#9499AB;}
+		.d2-2306023678 .stroke-N4{stroke:#CFD2DD;}
+		.d2-2306023678 .stroke-N5{stroke:#DEE1EB;}
+		.d2-2306023678 .stroke-N6{stroke:#EEF1F8;}
+		.d2-2306023678 .stroke-N7{stroke:#FFFFFF;}
+		.d2-2306023678 .stroke-B1{stroke:#0D32B2;}
+		.d2-2306023678 .stroke-B2{stroke:#0D32B2;}
+		.d2-2306023678 .stroke-B3{stroke:#E3E9FD;}
+		.d2-2306023678 .stroke-B4{stroke:#E3E9FD;}
+		.d2-2306023678 .stroke-B5{stroke:#EDF0FD;}
+		.d2-2306023678 .stroke-B6{stroke:#F7F8FE;}
+		.d2-2306023678 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-2306023678 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-2306023678 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-2306023678 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-2306023678 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-2306023678 .background-color-N1{background-color:#0A0F25;}
+		.d2-2306023678 .background-color-N2{background-color:#676C7E;}
+		.d2-2306023678 .background-color-N3{background-color:#9499AB;}
+		.d2-2306023678 .background-color-N4{background-color:#CFD2DD;}
+		.d2-2306023678 .background-color-N5{background-color:#DEE1EB;}
+		.d2-2306023678 .background-color-N6{background-color:#EEF1F8;}
+		.d2-2306023678 .background-color-N7{background-color:#FFFFFF;}
+		.d2-2306023678 .background-color-B1{background-color:#0D32B2;}
+		.d2-2306023678 .background-color-B2{background-color:#0D32B2;}
+		.d2-2306023678 .background-color-B3{background-color:#E3E9FD;}
+		.d2-2306023678 .background-color-B4{background-color:#E3E9FD;}
+		.d2-2306023678 .background-color-B5{background-color:#EDF0FD;}
+		.d2-2306023678 .background-color-B6{background-color:#F7F8FE;}
+		.d2-2306023678 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-2306023678 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-2306023678 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-2306023678 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-2306023678 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-2306023678 .color-N1{color:#0A0F25;}
+		.d2-2306023678 .color-N2{color:#676C7E;}
+		.d2-2306023678 .color-N3{color:#9499AB;}
+		.d2-2306023678 .color-N4{color:#CFD2DD;}
+		.d2-2306023678 .color-N5{color:#DEE1EB;}
+		.d2-2306023678 .color-N6{color:#EEF1F8;}
+		.d2-2306023678 .color-N7{color:#FFFFFF;}
+		.d2-2306023678 .color-B1{color:#0D32B2;}
+		.d2-2306023678 .color-B2{color:#0D32B2;}
+		.d2-2306023678 .color-B3{color:#E3E9FD;}
+		.d2-2306023678 .color-B4{color:#E3E9FD;}
+		.d2-2306023678 .color-B5{color:#EDF0FD;}
+		.d2-2306023678 .color-B6{color:#F7F8FE;}
+		.d2-2306023678 .color-AA2{color:#4A6FF3;}
+		.d2-2306023678 .color-AA4{color:#EDF0FD;}
+		.d2-2306023678 .color-AA5{color:#F7F8FE;}
+		.d2-2306023678 .color-AB4{color:#EDF0FD;}
+		.d2-2306023678 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><g id="d"><g class="shape" ><rect x="0.000000" y="0.000000" width="54.000000" height="66.000000" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="27.000000" y="38.500000" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">d</text></g><mask id="d2-2306023678" maskUnits="userSpaceOnUse" x="-101" y="-101" width="256" height="268">
+<rect x="-101" y="-101" width="256" height="268" fill="white"></rect>
+<rect x="22.500000" y="22.500000" width="9" height="21" fill="rgba(0,0,0,0.75)"></rect>
 </mask></svg></svg>

--- a/e2etests-cli/testdata/TestCLI_E2E/target-nested-index2.exp.svg
+++ b/e2etests-cli/testdata/TestCLI_E2E/target-nested-index2.exp.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" d2Version="v0.6.2-HEAD" preserveAspectRatio="xMinYMin meet" viewBox="0 0 255 268"><svg id="d2-svg" class="d2-14897664" width="255" height="268" viewBox="-101 -101 255 268"><rect x="-101.000000" y="-101.000000" width="255.000000" height="268.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
-.d2-14897664 .text-bold {
-	font-family: "d2-14897664-font-bold";
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" d2Version="v0.6.2-HEAD" preserveAspectRatio="xMinYMin meet" viewBox="0 0 369 268"><svg id="d2-svg" class="d2-3684577162" width="369" height="268" viewBox="-101 -101 369 268"><rect x="-101.000000" y="-101.000000" width="369.000000" height="268.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-3684577162 .text-bold {
+	font-family: "d2-3684577162-font-bold";
 }
 @font-face {
-	font-family: d2-14897664-font-bold;
-	src: url("data:application/font-woff;base64,d09GRgABAAAAAAYgAAoAAAAACtwAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAMAAAADAADQCYZ2x5ZgAAAYQAAADIAAAAyJ1bNpxoZWFkAAACTAAAADYAAAA2G38e1GhoZWEAAAKEAAAAJAAAACQKfwXBaG10eAAAAqgAAAAIAAAACATBAHpsb2NhAAACsAAAAAYAAAAGAGQALG1heHAAAAK4AAAAIAAAACAAGgD3bmFtZQAAAtgAAAMoAAAIKgjwVkFwb3N0AAAGAAAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAAwAAAAEAAwABAAAADAAEACQAAAAEAAQAAQAAAGH//wAAAGH///+gAAEAAAAAAAEAAAAFAFAAAAJiApQAAwAJAA8AEgAVAAAzESERJTMnJyMHNzM3NyMXAzcnAREHUAIS/qWkJykEKSkEKiCYH3pfXwFNXgKU/WxbTWJi9l87O/6eubr+jQFzugAAAgAq//QB1AH8ABkAIwAAFyImNTQ2NyYmIyIGByc2NjMyFhURIycjBgY3MjY3NQYGFRQWvkRQhJMCIykfQCQ1L2s6X2Z4CgQfRwgZJRNOPB8MVz9OWA8hJxgVYR0kbnL+5DMcI3IXE1cKKx0YFwAAAAEAAAACC4VEp3A7Xw889QABA+gAAAAA2F2ghAAAAADdZi82/jf+xAhtA/EAAQADAAIAAAAAAAAAAQAAA9j+7wAACJj+N/43CG0AAQAAAAAAAAAAAAAAAAAAAAICsgBQAg8AKgAAACwAZAAAAAEAAAACAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
+	font-family: d2-3684577162-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAAZ0AAoAAAAACzAAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAMgAAADIADQCfZ2x5ZgAAAYgAAAEUAAABFHIfZwtoZWFkAAACnAAAADYAAAA2G38e1GhoZWEAAALUAAAAJAAAACQKfwXCaG10eAAAAvgAAAAMAAAADAbCAJtsb2NhAAADBAAAAAgAAAAIAFgAtm1heHAAAAMMAAAAIAAAACAAGwD3bmFtZQAAAywAAAMoAAAIKgjwVkFwb3N0AAAGVAAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAAwAAAAEAAwABAAAADAAEACYAAAAEAAQAAQAAAGT//wAAAGP///+eAAEAAAAAAAEAAgAAAAAABQBQAAACYgKUAAMACQAPABIAFQAAMxEhESUzJycjBzczNzcjFwM3JwERB1ACEv6lpCcpBCkpBCogmB96X18BTV4ClP1sW01iYvZfOzv+nrm6/o0Bc7oAAAEAJP/0Ab0B/AAaAAAFIiYmNTQ2NjMyFhcHJiMiBhUUFjMyNjcXBgYBGUVvQUh2RC5HHEUjIDU/PzAYLhM6JVYMPXVSU3Q9HhdfHUxBQE0VD2AgGwAAAAACACf/9AH8Ar0AEwAgAAAXIiY1NDY2MzIWFyc1MxEjJyMGBjcyNjc1JiYjIgYVFBbyXG87XzQpOBkGk3gKBBpGAhgnEhMrFCM2LwyLeVF1PhwYTKn9QzEaI3gUGcsSDkNHSUUAAQAAAAILhZczC19fDzz1AAED6AAAAADYXaCEAAAAAN1mLzb+N/7ECG0D8QABAAMAAgAAAAAAAAABAAAD2P7vAAAImP43/jcIbQABAAAAAAAAAAAAAAAAAAAAAwKyAFAB0wAkAj0AJwAAACwAWACKAAEAAAADAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
 }]]></style><style type="text/css"><![CDATA[.shape {
   shape-rendering: geometricPrecision;
   stroke-linejoin: round;
@@ -18,78 +18,79 @@
   opacity: 0.5;
 }
 
-		.d2-14897664 .fill-N1{fill:#0A0F25;}
-		.d2-14897664 .fill-N2{fill:#676C7E;}
-		.d2-14897664 .fill-N3{fill:#9499AB;}
-		.d2-14897664 .fill-N4{fill:#CFD2DD;}
-		.d2-14897664 .fill-N5{fill:#DEE1EB;}
-		.d2-14897664 .fill-N6{fill:#EEF1F8;}
-		.d2-14897664 .fill-N7{fill:#FFFFFF;}
-		.d2-14897664 .fill-B1{fill:#0D32B2;}
-		.d2-14897664 .fill-B2{fill:#0D32B2;}
-		.d2-14897664 .fill-B3{fill:#E3E9FD;}
-		.d2-14897664 .fill-B4{fill:#E3E9FD;}
-		.d2-14897664 .fill-B5{fill:#EDF0FD;}
-		.d2-14897664 .fill-B6{fill:#F7F8FE;}
-		.d2-14897664 .fill-AA2{fill:#4A6FF3;}
-		.d2-14897664 .fill-AA4{fill:#EDF0FD;}
-		.d2-14897664 .fill-AA5{fill:#F7F8FE;}
-		.d2-14897664 .fill-AB4{fill:#EDF0FD;}
-		.d2-14897664 .fill-AB5{fill:#F7F8FE;}
-		.d2-14897664 .stroke-N1{stroke:#0A0F25;}
-		.d2-14897664 .stroke-N2{stroke:#676C7E;}
-		.d2-14897664 .stroke-N3{stroke:#9499AB;}
-		.d2-14897664 .stroke-N4{stroke:#CFD2DD;}
-		.d2-14897664 .stroke-N5{stroke:#DEE1EB;}
-		.d2-14897664 .stroke-N6{stroke:#EEF1F8;}
-		.d2-14897664 .stroke-N7{stroke:#FFFFFF;}
-		.d2-14897664 .stroke-B1{stroke:#0D32B2;}
-		.d2-14897664 .stroke-B2{stroke:#0D32B2;}
-		.d2-14897664 .stroke-B3{stroke:#E3E9FD;}
-		.d2-14897664 .stroke-B4{stroke:#E3E9FD;}
-		.d2-14897664 .stroke-B5{stroke:#EDF0FD;}
-		.d2-14897664 .stroke-B6{stroke:#F7F8FE;}
-		.d2-14897664 .stroke-AA2{stroke:#4A6FF3;}
-		.d2-14897664 .stroke-AA4{stroke:#EDF0FD;}
-		.d2-14897664 .stroke-AA5{stroke:#F7F8FE;}
-		.d2-14897664 .stroke-AB4{stroke:#EDF0FD;}
-		.d2-14897664 .stroke-AB5{stroke:#F7F8FE;}
-		.d2-14897664 .background-color-N1{background-color:#0A0F25;}
-		.d2-14897664 .background-color-N2{background-color:#676C7E;}
-		.d2-14897664 .background-color-N3{background-color:#9499AB;}
-		.d2-14897664 .background-color-N4{background-color:#CFD2DD;}
-		.d2-14897664 .background-color-N5{background-color:#DEE1EB;}
-		.d2-14897664 .background-color-N6{background-color:#EEF1F8;}
-		.d2-14897664 .background-color-N7{background-color:#FFFFFF;}
-		.d2-14897664 .background-color-B1{background-color:#0D32B2;}
-		.d2-14897664 .background-color-B2{background-color:#0D32B2;}
-		.d2-14897664 .background-color-B3{background-color:#E3E9FD;}
-		.d2-14897664 .background-color-B4{background-color:#E3E9FD;}
-		.d2-14897664 .background-color-B5{background-color:#EDF0FD;}
-		.d2-14897664 .background-color-B6{background-color:#F7F8FE;}
-		.d2-14897664 .background-color-AA2{background-color:#4A6FF3;}
-		.d2-14897664 .background-color-AA4{background-color:#EDF0FD;}
-		.d2-14897664 .background-color-AA5{background-color:#F7F8FE;}
-		.d2-14897664 .background-color-AB4{background-color:#EDF0FD;}
-		.d2-14897664 .background-color-AB5{background-color:#F7F8FE;}
-		.d2-14897664 .color-N1{color:#0A0F25;}
-		.d2-14897664 .color-N2{color:#676C7E;}
-		.d2-14897664 .color-N3{color:#9499AB;}
-		.d2-14897664 .color-N4{color:#CFD2DD;}
-		.d2-14897664 .color-N5{color:#DEE1EB;}
-		.d2-14897664 .color-N6{color:#EEF1F8;}
-		.d2-14897664 .color-N7{color:#FFFFFF;}
-		.d2-14897664 .color-B1{color:#0D32B2;}
-		.d2-14897664 .color-B2{color:#0D32B2;}
-		.d2-14897664 .color-B3{color:#E3E9FD;}
-		.d2-14897664 .color-B4{color:#E3E9FD;}
-		.d2-14897664 .color-B5{color:#EDF0FD;}
-		.d2-14897664 .color-B6{color:#F7F8FE;}
-		.d2-14897664 .color-AA2{color:#4A6FF3;}
-		.d2-14897664 .color-AA4{color:#EDF0FD;}
-		.d2-14897664 .color-AA5{color:#F7F8FE;}
-		.d2-14897664 .color-AB4{color:#EDF0FD;}
-		.d2-14897664 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><g id="a"><g class="shape" ><rect x="0.000000" y="0.000000" width="53.000000" height="66.000000" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="26.500000" y="38.500000" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">a</text></g><mask id="d2-14897664" maskUnits="userSpaceOnUse" x="-101" y="-101" width="255" height="268">
-<rect x="-101" y="-101" width="255" height="268" fill="white"></rect>
+		.d2-3684577162 .fill-N1{fill:#0A0F25;}
+		.d2-3684577162 .fill-N2{fill:#676C7E;}
+		.d2-3684577162 .fill-N3{fill:#9499AB;}
+		.d2-3684577162 .fill-N4{fill:#CFD2DD;}
+		.d2-3684577162 .fill-N5{fill:#DEE1EB;}
+		.d2-3684577162 .fill-N6{fill:#EEF1F8;}
+		.d2-3684577162 .fill-N7{fill:#FFFFFF;}
+		.d2-3684577162 .fill-B1{fill:#0D32B2;}
+		.d2-3684577162 .fill-B2{fill:#0D32B2;}
+		.d2-3684577162 .fill-B3{fill:#E3E9FD;}
+		.d2-3684577162 .fill-B4{fill:#E3E9FD;}
+		.d2-3684577162 .fill-B5{fill:#EDF0FD;}
+		.d2-3684577162 .fill-B6{fill:#F7F8FE;}
+		.d2-3684577162 .fill-AA2{fill:#4A6FF3;}
+		.d2-3684577162 .fill-AA4{fill:#EDF0FD;}
+		.d2-3684577162 .fill-AA5{fill:#F7F8FE;}
+		.d2-3684577162 .fill-AB4{fill:#EDF0FD;}
+		.d2-3684577162 .fill-AB5{fill:#F7F8FE;}
+		.d2-3684577162 .stroke-N1{stroke:#0A0F25;}
+		.d2-3684577162 .stroke-N2{stroke:#676C7E;}
+		.d2-3684577162 .stroke-N3{stroke:#9499AB;}
+		.d2-3684577162 .stroke-N4{stroke:#CFD2DD;}
+		.d2-3684577162 .stroke-N5{stroke:#DEE1EB;}
+		.d2-3684577162 .stroke-N6{stroke:#EEF1F8;}
+		.d2-3684577162 .stroke-N7{stroke:#FFFFFF;}
+		.d2-3684577162 .stroke-B1{stroke:#0D32B2;}
+		.d2-3684577162 .stroke-B2{stroke:#0D32B2;}
+		.d2-3684577162 .stroke-B3{stroke:#E3E9FD;}
+		.d2-3684577162 .stroke-B4{stroke:#E3E9FD;}
+		.d2-3684577162 .stroke-B5{stroke:#EDF0FD;}
+		.d2-3684577162 .stroke-B6{stroke:#F7F8FE;}
+		.d2-3684577162 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-3684577162 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-3684577162 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-3684577162 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-3684577162 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-3684577162 .background-color-N1{background-color:#0A0F25;}
+		.d2-3684577162 .background-color-N2{background-color:#676C7E;}
+		.d2-3684577162 .background-color-N3{background-color:#9499AB;}
+		.d2-3684577162 .background-color-N4{background-color:#CFD2DD;}
+		.d2-3684577162 .background-color-N5{background-color:#DEE1EB;}
+		.d2-3684577162 .background-color-N6{background-color:#EEF1F8;}
+		.d2-3684577162 .background-color-N7{background-color:#FFFFFF;}
+		.d2-3684577162 .background-color-B1{background-color:#0D32B2;}
+		.d2-3684577162 .background-color-B2{background-color:#0D32B2;}
+		.d2-3684577162 .background-color-B3{background-color:#E3E9FD;}
+		.d2-3684577162 .background-color-B4{background-color:#E3E9FD;}
+		.d2-3684577162 .background-color-B5{background-color:#EDF0FD;}
+		.d2-3684577162 .background-color-B6{background-color:#F7F8FE;}
+		.d2-3684577162 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-3684577162 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-3684577162 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-3684577162 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-3684577162 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-3684577162 .color-N1{color:#0A0F25;}
+		.d2-3684577162 .color-N2{color:#676C7E;}
+		.d2-3684577162 .color-N3{color:#9499AB;}
+		.d2-3684577162 .color-N4{color:#CFD2DD;}
+		.d2-3684577162 .color-N5{color:#DEE1EB;}
+		.d2-3684577162 .color-N6{color:#EEF1F8;}
+		.d2-3684577162 .color-N7{color:#FFFFFF;}
+		.d2-3684577162 .color-B1{color:#0D32B2;}
+		.d2-3684577162 .color-B2{color:#0D32B2;}
+		.d2-3684577162 .color-B3{color:#E3E9FD;}
+		.d2-3684577162 .color-B4{color:#E3E9FD;}
+		.d2-3684577162 .color-B5{color:#EDF0FD;}
+		.d2-3684577162 .color-B6{color:#F7F8FE;}
+		.d2-3684577162 .color-AA2{color:#4A6FF3;}
+		.d2-3684577162 .color-AA4{color:#EDF0FD;}
+		.d2-3684577162 .color-AA5{color:#F7F8FE;}
+		.d2-3684577162 .color-AB4{color:#EDF0FD;}
+		.d2-3684577162 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><g id="c"><g class="shape" ><rect x="0.000000" y="0.000000" width="53.000000" height="66.000000" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="26.500000" y="38.500000" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">c</text></g><g id="d"><g class="shape" ><rect x="113.000000" y="0.000000" width="54.000000" height="66.000000" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="140.000000" y="38.500000" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">d</text></g><mask id="d2-3684577162" maskUnits="userSpaceOnUse" x="-101" y="-101" width="369" height="268">
+<rect x="-101" y="-101" width="369" height="268" fill="white"></rect>
 <rect x="22.500000" y="22.500000" width="8" height="21" fill="rgba(0,0,0,0.75)"></rect>
+<rect x="135.500000" y="22.500000" width="9" height="21" fill="rgba(0,0,0,0.75)"></rect>
 </mask></svg></svg>

--- a/e2etests-cli/testdata/TestCLI_E2E/target-nested-index2.exp.svg
+++ b/e2etests-cli/testdata/TestCLI_E2E/target-nested-index2.exp.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" d2Version="v0.6.2-HEAD" preserveAspectRatio="xMinYMin meet" viewBox="0 0 255 268"><svg id="d2-svg" class="d2-14897664" width="255" height="268" viewBox="-101 -101 255 268"><rect x="-101.000000" y="-101.000000" width="255.000000" height="268.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-14897664 .text-bold {
+	font-family: "d2-14897664-font-bold";
+}
+@font-face {
+	font-family: d2-14897664-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAAYgAAoAAAAACtwAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAMAAAADAADQCYZ2x5ZgAAAYQAAADIAAAAyJ1bNpxoZWFkAAACTAAAADYAAAA2G38e1GhoZWEAAAKEAAAAJAAAACQKfwXBaG10eAAAAqgAAAAIAAAACATBAHpsb2NhAAACsAAAAAYAAAAGAGQALG1heHAAAAK4AAAAIAAAACAAGgD3bmFtZQAAAtgAAAMoAAAIKgjwVkFwb3N0AAAGAAAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAAwAAAAEAAwABAAAADAAEACQAAAAEAAQAAQAAAGH//wAAAGH///+gAAEAAAAAAAEAAAAFAFAAAAJiApQAAwAJAA8AEgAVAAAzESERJTMnJyMHNzM3NyMXAzcnAREHUAIS/qWkJykEKSkEKiCYH3pfXwFNXgKU/WxbTWJi9l87O/6eubr+jQFzugAAAgAq//QB1AH8ABkAIwAAFyImNTQ2NyYmIyIGByc2NjMyFhURIycjBgY3MjY3NQYGFRQWvkRQhJMCIykfQCQ1L2s6X2Z4CgQfRwgZJRNOPB8MVz9OWA8hJxgVYR0kbnL+5DMcI3IXE1cKKx0YFwAAAAEAAAACC4VEp3A7Xw889QABA+gAAAAA2F2ghAAAAADdZi82/jf+xAhtA/EAAQADAAIAAAAAAAAAAQAAA9j+7wAACJj+N/43CG0AAQAAAAAAAAAAAAAAAAAAAAICsgBQAg8AKgAAACwAZAAAAAEAAAACAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
+}]]></style><style type="text/css"><![CDATA[.shape {
+  shape-rendering: geometricPrecision;
+  stroke-linejoin: round;
+}
+.connection {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.blend {
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+
+		.d2-14897664 .fill-N1{fill:#0A0F25;}
+		.d2-14897664 .fill-N2{fill:#676C7E;}
+		.d2-14897664 .fill-N3{fill:#9499AB;}
+		.d2-14897664 .fill-N4{fill:#CFD2DD;}
+		.d2-14897664 .fill-N5{fill:#DEE1EB;}
+		.d2-14897664 .fill-N6{fill:#EEF1F8;}
+		.d2-14897664 .fill-N7{fill:#FFFFFF;}
+		.d2-14897664 .fill-B1{fill:#0D32B2;}
+		.d2-14897664 .fill-B2{fill:#0D32B2;}
+		.d2-14897664 .fill-B3{fill:#E3E9FD;}
+		.d2-14897664 .fill-B4{fill:#E3E9FD;}
+		.d2-14897664 .fill-B5{fill:#EDF0FD;}
+		.d2-14897664 .fill-B6{fill:#F7F8FE;}
+		.d2-14897664 .fill-AA2{fill:#4A6FF3;}
+		.d2-14897664 .fill-AA4{fill:#EDF0FD;}
+		.d2-14897664 .fill-AA5{fill:#F7F8FE;}
+		.d2-14897664 .fill-AB4{fill:#EDF0FD;}
+		.d2-14897664 .fill-AB5{fill:#F7F8FE;}
+		.d2-14897664 .stroke-N1{stroke:#0A0F25;}
+		.d2-14897664 .stroke-N2{stroke:#676C7E;}
+		.d2-14897664 .stroke-N3{stroke:#9499AB;}
+		.d2-14897664 .stroke-N4{stroke:#CFD2DD;}
+		.d2-14897664 .stroke-N5{stroke:#DEE1EB;}
+		.d2-14897664 .stroke-N6{stroke:#EEF1F8;}
+		.d2-14897664 .stroke-N7{stroke:#FFFFFF;}
+		.d2-14897664 .stroke-B1{stroke:#0D32B2;}
+		.d2-14897664 .stroke-B2{stroke:#0D32B2;}
+		.d2-14897664 .stroke-B3{stroke:#E3E9FD;}
+		.d2-14897664 .stroke-B4{stroke:#E3E9FD;}
+		.d2-14897664 .stroke-B5{stroke:#EDF0FD;}
+		.d2-14897664 .stroke-B6{stroke:#F7F8FE;}
+		.d2-14897664 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-14897664 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-14897664 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-14897664 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-14897664 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-14897664 .background-color-N1{background-color:#0A0F25;}
+		.d2-14897664 .background-color-N2{background-color:#676C7E;}
+		.d2-14897664 .background-color-N3{background-color:#9499AB;}
+		.d2-14897664 .background-color-N4{background-color:#CFD2DD;}
+		.d2-14897664 .background-color-N5{background-color:#DEE1EB;}
+		.d2-14897664 .background-color-N6{background-color:#EEF1F8;}
+		.d2-14897664 .background-color-N7{background-color:#FFFFFF;}
+		.d2-14897664 .background-color-B1{background-color:#0D32B2;}
+		.d2-14897664 .background-color-B2{background-color:#0D32B2;}
+		.d2-14897664 .background-color-B3{background-color:#E3E9FD;}
+		.d2-14897664 .background-color-B4{background-color:#E3E9FD;}
+		.d2-14897664 .background-color-B5{background-color:#EDF0FD;}
+		.d2-14897664 .background-color-B6{background-color:#F7F8FE;}
+		.d2-14897664 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-14897664 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-14897664 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-14897664 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-14897664 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-14897664 .color-N1{color:#0A0F25;}
+		.d2-14897664 .color-N2{color:#676C7E;}
+		.d2-14897664 .color-N3{color:#9499AB;}
+		.d2-14897664 .color-N4{color:#CFD2DD;}
+		.d2-14897664 .color-N5{color:#DEE1EB;}
+		.d2-14897664 .color-N6{color:#EEF1F8;}
+		.d2-14897664 .color-N7{color:#FFFFFF;}
+		.d2-14897664 .color-B1{color:#0D32B2;}
+		.d2-14897664 .color-B2{color:#0D32B2;}
+		.d2-14897664 .color-B3{color:#E3E9FD;}
+		.d2-14897664 .color-B4{color:#E3E9FD;}
+		.d2-14897664 .color-B5{color:#EDF0FD;}
+		.d2-14897664 .color-B6{color:#F7F8FE;}
+		.d2-14897664 .color-AA2{color:#4A6FF3;}
+		.d2-14897664 .color-AA4{color:#EDF0FD;}
+		.d2-14897664 .color-AA5{color:#F7F8FE;}
+		.d2-14897664 .color-AB4{color:#EDF0FD;}
+		.d2-14897664 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><g id="a"><g class="shape" ><rect x="0.000000" y="0.000000" width="53.000000" height="66.000000" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="26.500000" y="38.500000" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">a</text></g><mask id="d2-14897664" maskUnits="userSpaceOnUse" x="-101" y="-101" width="255" height="268">
+<rect x="-101" y="-101" width="255" height="268" fill="white"></rect>
+<rect x="22.500000" y="22.500000" width="8" height="21" fill="rgba(0,0,0,0.75)"></rect>
+</mask></svg></svg>


### PR DESCRIPTION

## Summary

Fixes a bug where the render target could be incorrect if the target path contains "index".

## Details
- fixes #1760 
- adds target-nested-index cli e2e tests

### before

<img width="387" alt="Screenshot 2023-12-07 at 1 44 21 PM" src="https://github.com/terrastruct/d2/assets/85081687/fb983956-9970-4c59-b9d6-3ec1819abdab">

### after

<img width="385" alt="Screenshot 2023-12-07 at 1 45 15 PM" src="https://github.com/terrastruct/d2/assets/85081687/606f1b55-beb5-4778-a433-6d9a1bae6b6e">
