### PR TITLE
d2oracle: fix set arrowhead fill

### DIFF
--- a/d2oracle/edit.go
+++ b/d2oracle/edit.go
@@ -653,8 +653,8 @@ func _set(g *d2graph.Graph, baseAST *d2ast.Map, key string, tag, value *string) 
 				}
 				if arrowhead != nil {
 					if reservedTargetKey == "" {
-						if len(mk.Key.Path[reservedIndex:]) != 2 {
-							return errors.New("malformed style setting, expected 2 part path")
+						if len(mk.Key.Path[reservedIndex:]) < 2 {
+							return errors.New("malformed style setting, expected >= 2 part path")
 						}
 						reservedTargetKey = mk.Key.Path[reservedIndex+1].Unbox().ScalarString()
 					}

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -1521,6 +1521,50 @@ a.b -> a.c: {style.animated: true}
 `,
 		},
 		{
+			name: "edge-arrowhead-filled/1",
+			text: `x -> y
+`,
+			key:   `(x -> y)[0].target-arrowhead.style.filled`,
+			value: go2.Pointer(`true`),
+
+			exp: `x -> y: {target-arrowhead.style.filled: true}
+`,
+		},
+		{
+			name: "edge-arrowhead-filled/2",
+			text: `x -> y: {
+  target-arrowhead: * {
+    shape: diamond
+  }
+}
+`,
+			key:   `(x -> y)[0].target-arrowhead.style.filled`,
+			value: go2.Pointer(`true`),
+
+			exp: `x -> y: {
+  target-arrowhead: * {
+    shape: diamond
+    style.filled: true
+  }
+}
+`,
+		},
+		{
+			name: "edge-arrowhead-filled/3",
+			text: `x -> y: {
+	target-arrowhead.shape: diamond
+}
+`,
+			key:   `(x -> y)[0].target-arrowhead.style.filled`,
+			value: go2.Pointer(`true`),
+
+			exp: `x -> y: {
+  target-arrowhead.shape: diamond
+  target-arrowhead.style.filled: true
+}
+`,
+		},
+		{
 			name: "edge_replace_arrowhead",
 			text: `x -> y: {target-arrowhead.shape: circle}
 `,

--- a/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.exp.json
+++ b/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.exp.json
@@ -1,0 +1,283 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:0:0-1:0:46",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:0:0-0:45:45",
+            "edges": [
+              {
+                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:0:0-0:6:6",
+                "src": {
+                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:0:0-0:1:1",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:0:0-0:1:1",
+                        "value": [
+                          {
+                            "string": "x",
+                            "raw_string": "x"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "src_arrow": "",
+                "dst": {
+                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:5:5-0:6:6",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:5:5-0:6:6",
+                        "value": [
+                          {
+                            "string": "y",
+                            "raw_string": "y"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "dst_arrow": ">"
+              }
+            ],
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:8:8-0:45:45",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:9:9-0:44:44",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:9:9-0:38:38",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:9:9-0:25:25",
+                              "value": [
+                                {
+                                  "string": "target-arrowhead",
+                                  "raw_string": "target-arrowhead"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:26:26-0:31:31",
+                              "value": [
+                                {
+                                  "string": "style",
+                                  "raw_string": "style"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:32:32-0:38:38",
+                              "value": [
+                                {
+                                  "string": "filled",
+                                  "raw_string": "filled"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "boolean": {
+                          "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:40:40-0:44:44",
+                          "value": true
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": [
+      {
+        "index": 0,
+        "isCurve": false,
+        "src_arrow": false,
+        "dst_arrow": true,
+        "dstArrowhead": {
+          "label": {
+            "value": ""
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {
+            "filled": {
+              "value": "true"
+            }
+          },
+          "near_key": null,
+          "shape": {
+            "value": ""
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "references": [
+          {
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": ""
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": ""
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ],
+    "objects": [
+      {
+        "id": "x",
+        "id_val": "x",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "x"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "y",
+        "id_val": "y",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:5:5-0:6:6",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/1.d2,0:5:5-0:6:6",
+                    "value": [
+                      {
+                        "string": "y",
+                        "raw_string": "y"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "y"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": "<nil>"
+}

--- a/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.exp.json
+++ b/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.exp.json
@@ -1,0 +1,344 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:0:0-6:0:82",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:0:0-5:1:81",
+            "edges": [
+              {
+                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:0:0-0:6:6",
+                "src": {
+                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:0:0-0:1:1",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:0:0-0:1:1",
+                        "value": [
+                          {
+                            "string": "x",
+                            "raw_string": "x"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "src_arrow": "",
+                "dst": {
+                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:5:5-0:6:6",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:5:5-0:6:6",
+                        "value": [
+                          {
+                            "string": "y",
+                            "raw_string": "y"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "dst_arrow": ">"
+              }
+            ],
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:8:8-5:1:81",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,1:2:12-4:3:79",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,1:2:12-1:18:28",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,1:2:12-1:18:28",
+                              "value": [
+                                {
+                                  "string": "target-arrowhead",
+                                  "raw_string": "target-arrowhead"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,1:20:30-1:21:31",
+                          "value": [
+                            {
+                              "string": "*",
+                              "raw_string": "*"
+                            }
+                          ]
+                        }
+                      },
+                      "value": {
+                        "map": {
+                          "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,1:22:32-4:3:79",
+                          "nodes": [
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,2:4:38-2:18:52",
+                                "key": {
+                                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,2:4:38-2:9:43",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,2:4:38-2:9:43",
+                                        "value": [
+                                          {
+                                            "string": "shape",
+                                            "raw_string": "shape"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "unquoted_string": {
+                                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,2:11:45-2:18:52",
+                                    "value": [
+                                      {
+                                        "string": "diamond",
+                                        "raw_string": "diamond"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,3:4:57-3:22:75",
+                                "key": {
+                                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,3:4:57-3:16:69",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,3:4:57-3:9:62",
+                                        "value": [
+                                          {
+                                            "string": "style",
+                                            "raw_string": "style"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,3:10:63-3:16:69",
+                                        "value": [
+                                          {
+                                            "string": "filled",
+                                            "raw_string": "filled"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "boolean": {
+                                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,3:18:71-3:22:75",
+                                    "value": true
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": [
+      {
+        "index": 0,
+        "isCurve": false,
+        "src_arrow": false,
+        "dst_arrow": true,
+        "dstArrowhead": {
+          "label": {
+            "value": "*"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {
+            "filled": {
+              "value": "true"
+            }
+          },
+          "near_key": null,
+          "shape": {
+            "value": "diamond"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "references": [
+          {
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": ""
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": ""
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ],
+    "objects": [
+      {
+        "id": "x",
+        "id_val": "x",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "x"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "y",
+        "id_val": "y",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:5:5-0:6:6",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/2.d2,0:5:5-0:6:6",
+                    "value": [
+                      {
+                        "string": "y",
+                        "raw_string": "y"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "y"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": "<nil>"
+}

--- a/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.exp.json
+++ b/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.exp.json
@@ -1,0 +1,327 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:0:0-4:0:84",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:0:0-3:1:83",
+            "edges": [
+              {
+                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:0:0-0:6:6",
+                "src": {
+                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:0:0-0:1:1",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:0:0-0:1:1",
+                        "value": [
+                          {
+                            "string": "x",
+                            "raw_string": "x"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "src_arrow": "",
+                "dst": {
+                  "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:5:5-0:6:6",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:5:5-0:6:6",
+                        "value": [
+                          {
+                            "string": "y",
+                            "raw_string": "y"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "dst_arrow": ">"
+              }
+            ],
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:8:8-3:1:83",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,1:2:12-1:33:43",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,1:2:12-1:24:34",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,1:2:12-1:18:28",
+                              "value": [
+                                {
+                                  "string": "target-arrowhead",
+                                  "raw_string": "target-arrowhead"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,1:19:29-1:24:34",
+                              "value": [
+                                {
+                                  "string": "shape",
+                                  "raw_string": "shape"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,1:26:36-1:33:43",
+                          "value": [
+                            {
+                              "string": "diamond",
+                              "raw_string": "diamond"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,2:2:46-2:37:81",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,2:2:46-2:31:75",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,2:2:46-2:18:62",
+                              "value": [
+                                {
+                                  "string": "target-arrowhead",
+                                  "raw_string": "target-arrowhead"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,2:19:63-2:24:68",
+                              "value": [
+                                {
+                                  "string": "style",
+                                  "raw_string": "style"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,2:25:69-2:31:75",
+                              "value": [
+                                {
+                                  "string": "filled",
+                                  "raw_string": "filled"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "boolean": {
+                          "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,2:33:77-2:37:81",
+                          "value": true
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": [
+      {
+        "index": 0,
+        "isCurve": false,
+        "src_arrow": false,
+        "dst_arrow": true,
+        "dstArrowhead": {
+          "label": {
+            "value": ""
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {
+            "filled": {
+              "value": "true"
+            }
+          },
+          "near_key": null,
+          "shape": {
+            "value": "diamond"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "references": [
+          {
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": ""
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": ""
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ],
+    "objects": [
+      {
+        "id": "x",
+        "id_val": "x",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "x"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      },
+      {
+        "id": "y",
+        "id_val": "y",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:5:5-0:6:6",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/edge-arrowhead-filled/3.d2,0:5:5-0:6:6",
+                    "value": [
+                      {
+                        "string": "y",
+                        "raw_string": "y"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": 0
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "y"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": "<nil>"
+}


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

only `edge-arrowhead-filled/3` was failing, but the other 2 included for comprehensiveness