### PR TITLE
d2oracle: set null

### DIFF
--- a/d2oracle/edit.go
+++ b/d2oracle/edit.go
@@ -332,7 +332,11 @@ func _set(g *d2graph.Graph, baseAST *d2ast.Map, key string, tag, value *string) 
 	}
 
 	if value != nil {
-		mk.Value = d2ast.MakeValueBox(d2ast.RawString(*value, false))
+		if *value == "null" {
+			mk.Value = d2ast.MakeValueBox(&d2ast.Null{})
+		} else {
+			mk.Value = d2ast.MakeValueBox(d2ast.RawString(*value, false))
+		}
 	} else {
 		mk.Value = d2ast.ValueBox{}
 	}

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -2456,6 +2456,16 @@ a -> b: {style.stroke: green}
 a -> b
 `,
 		},
+		{
+			name: "set-null",
+
+			text: `a
+`,
+			key:   `a.style.fill-pattern`,
+			value: go2.Pointer(`null`),
+			exp: `a: {style.fill-pattern: null}
+`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/testdata/d2oracle/TestSet/set-null.exp.json
+++ b/testdata/d2oracle/TestSet/set-null.exp.json
@@ -1,0 +1,150 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:0:0-1:0:30",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:0:0-0:29:29",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:3:3-0:29:29",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:4:4-0:28:28",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:4:4-0:22:22",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:4:4-0:9:9",
+                              "value": [
+                                {
+                                  "string": "style",
+                                  "raw_string": "style"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:10:10-0:22:22",
+                              "value": [
+                                {
+                                  "string": "fill-pattern",
+                                  "raw_string": "fill-pattern"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "null": {
+                          "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:24:24-0:28:28"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "a",
+        "id_val": "a",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestSet/set-null.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "a",
+                        "raw_string": "a"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "a"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": "<nil>"
+}


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

allow setting `null`. Delete does null things, but this is useful for nulling values set by themes, which is not a consideration d2oracle makes.