### PR TITLE
doc: add remark-d2 to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ let us know and we'll be happy to include it here!
 - **Logseq-D2**: [https://github.com/b-yp/logseq-d2](https://github.com/b-yp/logseq-d2)
 - **ent2d2**: [https://github.com/tmc/ent2d2](https://github.com/tmc/ent2d2)
 - **MkDocs Plugin**: [https://github.com/landmaj/mkdocs-d2-plugin](https://github.com/landmaj/mkdocs-d2-plugin)
+- **Remark Plugin**: [https://github.com/mech-a/remark-d2](https://github.com/mech-a/remark-d2)
 
 ### Misc
 


### PR DESCRIPTION
This is a plugin that allows compiling D2 blocks in markdown files into markdown/html images. I made it a while back and it's in the D2 documentation website, but I forgot to add a PR for here. Here is the PR that was accepted for d2-docs: https://github.com/terrastruct/d2-docs/pull/180