### PR TITLE
fix: add url escaping to markdown processing #1898

### DIFF
--- a/lib/textmeasure/markdown.go
+++ b/lib/textmeasure/markdown.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"net/url"
 	"regexp"
 	"strings"
 
@@ -81,22 +80,14 @@ func HeaderToFontSize(baseFontSize int, header string) int {
 }
 
 func preProcessMarkdown(m string) string {
-	// This is a simplified pattern; a more robust one would be complex
-	urlRegex := regexp.MustCompile(`\b((?:https?|ftp)://[^\s"']+&\S*)\b`)
+    urlRegex := regexp.MustCompile(`(?i)(?:href|src)="(https?|ftp)://[^\s"]+&\S*"`)
 
-	output := urlRegex.ReplaceAllStringFunc(m, func(urlStr string) string {
-		// Attempt to parse
-		parsedURL, err := url.Parse(urlStr)
-		if err != nil {
-			return urlStr
-		}
+    output := urlRegex.ReplaceAllStringFunc(m, func(match string) string {
+        modifiedURL := strings.ReplaceAll(match, "&", "%26")
+        return modifiedURL
+    })
 
-		// Escape only ampersands using strings.ReplaceAll
-		escapedURL := strings.ReplaceAll(parsedURL.String(), "&", "%26")
-		return escapedURL
-	})
-
-	return output
+    return output
 }
 
 func RenderMarkdown(m string) (string, error) {

--- a/lib/textmeasure/markdown.go
+++ b/lib/textmeasure/markdown.go
@@ -82,7 +82,7 @@ func HeaderToFontSize(baseFontSize int, header string) int {
 
 func preProcessMarkdown(m string) string {
 	// This is a simplified pattern; a more robust one would be complex
-	urlRegex := regexp.MustCompile(`\b((?:https?|ftp)://[^\s"']+)\b`)
+	urlRegex := regexp.MustCompile(`\b((?:https?|ftp)://[^\s"']+&\S*)\b`)
 
 	output := urlRegex.ReplaceAllStringFunc(m, func(urlStr string) string {
 		// Attempt to parse

--- a/lib/textmeasure/markdown.go
+++ b/lib/textmeasure/markdown.go
@@ -80,32 +80,29 @@ func HeaderToFontSize(baseFontSize int, header string) int {
 	return 0
 }
 
-func preProcessMarkdown(m string) (string, error) {
-    // This is a simplified pattern; a more robust one would be complex
-    urlRegex := regexp.MustCompile(`\b((?:https?|ftp)://[^\s"']+)\b`) 
+func preProcessMarkdown(m string) string {
+	// This is a simplified pattern; a more robust one would be complex
+	urlRegex := regexp.MustCompile(`\b((?:https?|ftp)://[^\s"']+)\b`)
 
-    output := urlRegex.ReplaceAllStringFunc(m, func(urlStr string) string {
-        parsedURL, err := url.Parse(urlStr)
-        if err != nil {
-            // If parsing fails, return the original for basic error handling
-            return urlStr 
-        }
+	output := urlRegex.ReplaceAllStringFunc(m, func(urlStr string) string {
+		// Attempt to parse
+		parsedURL, err := url.Parse(urlStr)
+		if err != nil {
+			return urlStr
+		}
 
-        escapedURL := url.QueryEscape(parsedURL.String()) 
-        return escapedURL
-    })
+		// Escape only ampersands using strings.ReplaceAll
+		escapedURL := strings.ReplaceAll(parsedURL.String(), "&", "%26")
+		return escapedURL
+	})
 
-    return output, nil
+	return output
 }
 
 func RenderMarkdown(m string) (string, error) {
 	var output bytes.Buffer
 
-	pre, err := preProcessMarkdown(m)
-
-	if err != nil {
-		return "", err
-	}
+	pre := preProcessMarkdown(m)
 
 	if err := markdownRenderer.Convert([]byte(pre), &output); err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
Fix for issue #1898

I saw in the issue thread it was suggested to create a goldmark extension, which I'm still open to doing but I wanted to suggest a simpler regex based solution in this PR. Works on the md from the issue as well as a few other test cases:
```
memo: |md
  <a href="https://www.google.com/search?q=d2&newwindow=1">d2</a>
|
```