### PR TITLE
add installer tests

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,19 @@
+name: Installer Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: installer (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu, windows, macos]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install D2
+        run: |
+          cat install.sh | sh -s --


### PR DESCRIPTION
the installer currently fails on windows. This PR adds a job which tests the installer against different targets.
This doesn't fix the breakage, but should catch it next time.