### PR TITLE
Add new dark theme: Dark berry blue

### DIFF
--- a/d2themes/d2themescatalog/catalog.go
+++ b/d2themes/d2themescatalog/catalog.go
@@ -30,6 +30,7 @@ var LightCatalog = []d2themes.Theme{
 var DarkCatalog = []d2themes.Theme{
 	DarkMauve,
 	DarkFlagshipTerrastruct,
+    DarkBerryBlue,
 }
 
 func Find(id int64) d2themes.Theme {

--- a/d2themes/d2themescatalog/dark_berry_blue.go
+++ b/d2themes/d2themescatalog/dark_berry_blue.go
@@ -1,0 +1,25 @@
+package d2themescatalog
+
+import "oss.terrastruct.com/d2/d2themes"
+
+var DarkBerryBlue = d2themes.Theme{
+	ID:   205,
+	Name: "Dark berry blue",
+	Colors: d2themes.ColorPalette{
+		Neutrals: d2themes.DarkNeutral,
+
+		B1: "#E5F3FF",
+		B2: "#BCDDFB",
+		B3: "#77AFE3",
+		B4: "#2353DD",
+		B5: "#0F36A7",
+		B6: "#102566",
+
+		AA2: "#DACEFB",
+		AA4: "#A162D3",
+		AA5: "#5639A5",
+
+		AB4: "#FFDEF1",
+		AB5: "#EA99C6",
+	},
+}


### PR DESCRIPTION
The number of built-in dark themes is lacking compared to the light themes.
This PR aims to be a first step to alleviate this, in submitting a dark variant of "Mixed Berry Blue".

As a side note: it would be logical to make the IDs of themes a bit more symmetrical: since the ID category seems to be `200 <= DarkThemeID < 300`, it is a logical expectation that a dark variant of an existing light theme is `LightID + 200`?

It would be a reasonable goal to work toward "dark theme coverage" in this sense too?
