### PR TITLE
cli: Force `d2 fmt` operate when the input file is stdin

### DIFF
--- a/d2cli/fmt.go
+++ b/d2cli/fmt.go
@@ -42,7 +42,7 @@ func fmtCmd(ctx context.Context, ms *xmain.State) (err error) {
 		}
 
 		output := []byte(d2format.Format(m))
-		if !bytes.Equal(output, input) {
+		if !bytes.Equal(output, input) || inputPath == "-" {
 			if err := ms.WritePath(inputPath, output); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR fixes #1577.

The change is obvious. Previously, `d2 fmt` CLI command was no-op when the content is unchanged. However, this check should be skipped if the input file is stdin–because editor integrations would use it for on-the-fly reformatting.