### PR TITLE
d2compiler: validate that reserved keywords have values

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -13,6 +13,7 @@
   - This is a breaking change. Previously Latex blocks required escaping the backslash. So
     for older D2 versions, you should remove the excess backslashes.
 - Links: non-http url scheme links are supported (e.g. `x.link: vscode://file/`) [#2237](https://github.com/terrastruct/d2/issues/2237)
+- Compiler: reserved keywords with missing values error instead of silently doing nothing [#2251](https://github.com/terrastruct/d2/pull/2251)
 
 #### Bugfixes ⛑️
 

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -239,8 +239,6 @@ func (c *compiler) compileMap(obj *d2graph.Object, m *d2ir.Map) {
 					}
 				}
 			}
-		} else {
-			c.errorf(class.LastRef().AST(), "class missing value")
 		}
 
 		for _, className := range classNames {
@@ -505,6 +503,8 @@ func (c *compiler) compileReserved(attrs *d2graph.Attributes, f *d2ir.Field) {
 			default:
 				c.errorf(f.LastPrimaryKey(), "reserved field %v does not accept composite", f.Name.ScalarString())
 			}
+		} else {
+			c.errorf(f.LastRef().AST(), `reserved field "%v" must have a value`, f.Name.ScalarString())
 		}
 		return
 	}
@@ -817,8 +817,6 @@ func (c *compiler) compileEdgeMap(edge *d2graph.Edge, m *d2ir.Map) {
 					}
 				}
 			}
-		} else {
-			c.errorf(class.LastRef().AST(), "class missing value")
 		}
 
 		for _, className := range classNames {

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -128,6 +128,18 @@ x: {
 			},
 		},
 		{
+			name: "reserved_missing_values",
+			text: `foobar: {
+  width
+  bottom
+  left
+  right
+}
+`,
+			expErr: `d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:2:3: reserved field "width" must have a value
+d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:4:3: reserved field "left" must have a value`,
+		},
+		{
 			name: "positions_negative",
 			text: `hey: {
 	top: 200
@@ -3066,7 +3078,7 @@ object: {
 			name: "no-class-primary",
 			text: `x.class
 `,
-			expErr: `d2/testdata/d2compiler/TestCompile/no-class-primary.d2:1:3: class missing value`,
+			expErr: `d2/testdata/d2compiler/TestCompile/no-class-primary.d2:1:3: reserved field "class" must have a value`,
 		},
 		{
 			name: "no-class-inside-classes",

--- a/testdata/d2compiler/TestCompile/no-class-primary.exp.json
+++ b/testdata/d2compiler/TestCompile/no-class-primary.exp.json
@@ -4,7 +4,7 @@
     "errs": [
       {
         "range": "d2/testdata/d2compiler/TestCompile/no-class-primary.d2,0:2:2-0:7:7",
-        "errmsg": "d2/testdata/d2compiler/TestCompile/no-class-primary.d2:1:3: class missing value"
+        "errmsg": "d2/testdata/d2compiler/TestCompile/no-class-primary.d2:1:3: reserved field \"class\" must have a value"
       }
     ]
   }

--- a/testdata/d2compiler/TestCompile/reserved_missing_values.exp.json
+++ b/testdata/d2compiler/TestCompile/reserved_missing_values.exp.json
@@ -1,0 +1,15 @@
+{
+  "graph": null,
+  "err": {
+    "errs": [
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2,1:2:12-1:7:17",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:2:3: reserved field width must have a value"
+      },
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2,3:2:29-3:6:33",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:4:3: reserved field left must have a value"
+      }
+    ]
+  }
+}

--- a/testdata/d2compiler/TestCompile/reserved_missing_values.exp.json
+++ b/testdata/d2compiler/TestCompile/reserved_missing_values.exp.json
@@ -4,11 +4,11 @@
     "errs": [
       {
         "range": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2,1:2:12-1:7:17",
-        "errmsg": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:2:3: reserved field width must have a value"
+        "errmsg": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:2:3: reserved field \"width\" must have a value"
       },
       {
         "range": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2,3:2:29-3:6:33",
-        "errmsg": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:4:3: reserved field left must have a value"
+        "errmsg": "d2/testdata/d2compiler/TestCompile/reserved_missing_values.d2:4:3: reserved field \"left\" must have a value"
       }
     ]
   }


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

closes https://github.com/terrastruct/d2/issues/1596