### PR TITLE
cli: Implement d2 fmt --check

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,7 +4,7 @@
 - Connections now support `link` [#1955](https://github.com/terrastruct/d2/pull/1955)
 - Vars: vars in markdown blocks are substituted [#2218](https://github.com/terrastruct/d2/pull/2218)
 - Markdown: Github-flavored tables work in `md` blocks [#2221](https://github.com/terrastruct/d2/pull/2221)
-- `d2 fm` now supports a `--check` flag [#2253](https://github.com/terrastruct/d2/pull/2253)
+- `d2 fmt` now supports a `--check` flag [#2253](https://github.com/terrastruct/d2/pull/2253)
 
 #### Improvements 🧹
 

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 - Connections now support `link` [#1955](https://github.com/terrastruct/d2/pull/1955)
 - Vars: vars in markdown blocks are substituted [#2218](https://github.com/terrastruct/d2/pull/2218)
 - Markdown: Github-flavored tables work in `md` blocks [#2221](https://github.com/terrastruct/d2/pull/2221)
+- `d2 fm` now supports a `--check` flag [#2253](https://github.com/terrastruct/d2/pull/2253)
 
 #### Improvements 🧹
 

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -125,6 +125,9 @@ In watch mode, images used in icons are cached for subsequent compilations. This
 .It Fl -timeout Ar 120
 The maximum number of seconds that D2 runs for before timing out and exiting. When rendering a large diagram, it is recommended to increase this value
 .Ns .
+.It Fl -check Ar false
+Check that the specified files are formatted correctly
+.Ns .
 .It Fl h , -help
 Print usage information and exit
 .Ns .
@@ -180,6 +183,8 @@ See --font-semibold flag.
 See --animate-interval flag.
 .It Ev Sy D2_TIMEOUT
 See --timeout flag.
+.It Ev Sy D2_CHECK
+See --check flag.
 .El
 .Bl -tag -width Ds
 .It Ev Sy DEBUG

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -119,6 +119,11 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	fontBoldFlag := ms.Opts.String("D2_FONT_BOLD", "font-bold", "", "", "path to .ttf file to use for the bold font. If none provided, Source Sans Pro Bold is used.")
 	fontSemiboldFlag := ms.Opts.String("D2_FONT_SEMIBOLD", "font-semibold", "", "", "path to .ttf file to use for the semibold font. If none provided, Source Sans Pro Semibold is used.")
 
+	checkFlag, err := ms.Opts.Bool("D2_CHECK", "check", "", false, "check that the specified files are formatted correctly.")
+	if err != nil {
+		return err
+	}
+
 	plugins, err := d2plugin.ListPlugins(ctx)
 	if err != nil {
 		return err
@@ -153,7 +158,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 			themesCmd(ctx, ms)
 			return nil
 		case "fmt":
-			return fmtCmd(ctx, ms)
+			return fmtCmd(ctx, ms, *checkFlag)
 		case "version":
 			if len(ms.Opts.Flags.Args()) > 1 {
 				return xmain.UsageErrorf("version subcommand accepts no arguments")

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -1006,16 +1006,26 @@ layers: {
 			},
 		},
 		{
-			name: "fmt-check",
+			name: "fmt-check-unformatted",
 			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
 				writeFile(t, dir, "foo.d2", `a ---> b`)
 				writeFile(t, dir, "bar.d2", `x ---> y`)
-				err := runTestMainPersist(t, ctx, dir, env, "fmt", "--check", "foo.d2", "bar.d2")
+				writeFile(t, dir, "baz.d2", "a -> z\n")
+				err := runTestMainPersist(t, ctx, dir, env, "fmt", "--check", "foo.d2", "bar.d2", "baz.d2")
 				assert.ErrorString(t, err, "failed to wait xmain test: e2etests-cli/d2: failed to fmt: exiting with code 1: found 2 unformatted files. Run d2 fmt to fix.")
 				gotFoo := readFile(t, dir, "foo.d2")
 				gotBar := readFile(t, dir, "bar.d2")
 				assert.Equal(t, "a ---> b", string(gotFoo))
 				assert.Equal(t, "x ---> y", string(gotBar))
+			},
+		},
+		{
+			name: "fmt-check-formatted",
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "foo.d2", "a -> b\n")
+				writeFile(t, dir, "bar.d2", "x -> y\n")
+				err := runTestMainPersist(t, ctx, dir, env, "fmt", "--check", "foo.d2", "bar.d2")
+				assert.Success(t, err)
 			},
 		},
 		{

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -1006,6 +1006,19 @@ layers: {
 			},
 		},
 		{
+			name: "fmt-check",
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "foo.d2", `a ---> b`)
+				writeFile(t, dir, "bar.d2", `x ---> y`)
+				err := runTestMainPersist(t, ctx, dir, env, "fmt", "--check", "foo.d2", "bar.d2")
+				assert.ErrorString(t, err, "failed to wait xmain test: e2etests-cli/d2: failed to fmt: exiting with code 1: found 2 unformatted files. Run d2 fmt to fix.")
+				gotFoo := readFile(t, dir, "foo.d2")
+				gotBar := readFile(t, dir, "bar.d2")
+				assert.Equal(t, "a ---> b", string(gotFoo))
+				assert.Equal(t, "x ---> y", string(gotBar))
+			},
+		},
+		{
 			name:   "watch-regular",
 			serial: true,
 			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

This PR implements a `--check` flag as described in https://github.com/terrastruct/d2/issues/1180. I followed what Prettier does: it logs a warning for each unformatted file, and if any were found, it prints the number of unformatted files and a "run XYZ to fix" message.

Closes #1180.