### PR TITLE
docs: add alternative tree-sitter grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ let us know and we'll be happy to include it here!
 
 ### Community plugins
 
-- **Tree-sitter grammar**: [https://git.pleshevski.ru/pleshevskiy/tree-sitter-d2](https://git.pleshevski.ru/pleshevskiy/tree-sitter-d2)
+- **Tree-sitter grammar**: [https://github.com/ravsii/tree-sitter-d2](https://github.com/ravsii/tree-sitter-d2)
 - **Emacs major mode**: [https://github.com/andorsk/d2-mode](https://github.com/andorsk/d2-mode)
 - **Goldmark extension**: [https://github.com/FurqanSoftware/goldmark-d2](https://github.com/FurqanSoftware/goldmark-d2)
 - **Telegram bot**: [https://github.com/meinside/telegram-d2-bot](https://github.com/meinside/telegram-d2-bot)


### PR DESCRIPTION
Hi! I'm the author of an alternative Tree-sitter grammar, which is being developed [here](https://github.com/ravsii/tree-sitter-d2). Could we add it to the list of community projects in the `README.md`? Unfortunately, Pleshevskiy (the author of the first grammar) no longer maintains their project, it seems. 

I really appreciate that my repository was added to the official [docs](https://d2lang.com/tour/extensions/#:~:text=Tree%2Dsitter%20grammar%202%3A%20https%3A//github.com/ravsii/tree%2Dsitter%2Dd2) even before I managed to make the project fully usable, haha. While it's still a work in progress, my grammar already supports all the basic use cases for regular diagrams, SQL tables, sequence diagrams, and grid diagrams. 

Additionally, there are comparisons and installation instructions available for both `Neovim` and `Helix` users in the repo's README.

Please let me know if I missed anything!
