### PR TITLE
cli: add format flag to support PNG output to stdout 

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,8 +4,8 @@
 - Connections now support `link` [#1955](https://github.com/terrastruct/d2/pull/1955)
 - Vars: vars in markdown blocks are substituted [#2218](https://github.com/terrastruct/d2/pull/2218)
 - Markdown: Github-flavored tables work in `md` blocks [#2221](https://github.com/terrastruct/d2/pull/2221)
-- CLI: PNG output to stdout is supported using `--stdout-format png -` [#2260](https://github.com/terrastruct/d2/pull/2260)
 - `d2 fmt` now supports a `--check` flag [#2253](https://github.com/terrastruct/d2/pull/2253)
+- CLI: PNG output to stdout is supported using `--stdout-format png -` [#2291](https://github.com/terrastruct/d2/pull/2291)
 
 #### Improvements 🧹
 

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -4,6 +4,7 @@
 - Connections now support `link` [#1955](https://github.com/terrastruct/d2/pull/1955)
 - Vars: vars in markdown blocks are substituted [#2218](https://github.com/terrastruct/d2/pull/2218)
 - Markdown: Github-flavored tables work in `md` blocks [#2221](https://github.com/terrastruct/d2/pull/2221)
+- CLI: PNG output to stdout is supported using `--stdout-format png -` [#2260](https://github.com/terrastruct/d2/pull/2260)
 - `d2 fmt` now supports a `--check` flag [#2253](https://github.com/terrastruct/d2/pull/2253)
 
 #### Improvements 🧹

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -134,6 +134,9 @@ Print usage information and exit
 .It Fl v , -version
 Print version information and exit
 .Ns .
+.It Fl -stdout-format Ar string
+Set the output format when writing to stdout. Supported formats are: png, svg. Only used when output is set to stdout (-)
+.Ns .
 .El
 .Sh SUBCOMMANDS
 .Bl -tag -width Fl
@@ -197,6 +200,8 @@ See -h[ost] flag.
 See -p[ort] flag.
 .It Ev Sy BROWSER
 See --browser flag.
+.It Ev Sy D2_STDOUT_FORMAT
+See --stdout-format flag.
 .El
 .Sh SEE ALSO
 .Xr d2plugin-tala 1

--- a/d2cli/export.go
+++ b/d2cli/export.go
@@ -1,7 +1,9 @@
 package d2cli
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 type exportExtension string
@@ -13,6 +15,24 @@ const PDF exportExtension = ".pdf"
 const SVG exportExtension = ".svg"
 
 var SUPPORTED_EXTENSIONS = []exportExtension{SVG, PNG, PDF, PPTX, GIF}
+
+var STDOUT_FORMAT_MAP = map[string]exportExtension{
+	"png": PNG,
+	"svg": SVG,
+}
+
+var SUPPORTED_STDOUT_FORMATS = []string{"png", "svg"}
+
+func getOutputFormat(stdoutFormatFlag *string, outputPath string) (exportExtension, error) {
+	if *stdoutFormatFlag != "" {
+		format := strings.ToLower(*stdoutFormatFlag)
+		if ext, ok := STDOUT_FORMAT_MAP[format]; ok {
+			return ext, nil
+		}
+		return "", fmt.Errorf("%s is not a supported format. Supported formats are: %s", *stdoutFormatFlag, SUPPORTED_STDOUT_FORMATS)
+	}
+	return getExportExtension(outputPath), nil
+}
 
 func getExportExtension(outputPath string) exportExtension {
 	ext := filepath.Ext(outputPath)

--- a/d2cli/export_test.go
+++ b/d2cli/export_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestOutputFormat(t *testing.T) {
 	type testCase struct {
+		stdoutFormatFlag          string
 		outputPath                string
 		extension                 exportExtension
 		supportsDarkTheme         bool
@@ -40,6 +41,15 @@ func TestOutputFormat(t *testing.T) {
 			supportsAnimation:         true,
 			requiresAnimationInterval: false,
 			requiresPngRender:         false,
+		},
+		{
+			stdoutFormatFlag:          "png",
+			outputPath:                "-",
+			extension:                 PNG,
+			supportsDarkTheme:         false,
+			supportsAnimation:         false,
+			requiresAnimationInterval: false,
+			requiresPngRender:         true,
 		},
 		{
 			outputPath:                "/out.png",
@@ -78,7 +88,8 @@ func TestOutputFormat(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.outputPath, func(t *testing.T) {
-			extension := getExportExtension(tc.outputPath)
+			extension, err := getOutputFormat(&tc.stdoutFormatFlag, tc.outputPath)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.extension, extension)
 			assert.Equal(t, tc.supportsAnimation, extension.supportsAnimation())
 			assert.Equal(t, tc.supportsDarkTheme, extension.supportsDarkTheme())

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -57,6 +57,7 @@ type watcherOpts struct {
 	forceAppendix   bool
 	pw              png.Playwright
 	fontFamily      *d2fonts.FontFamily
+	outputFormat    exportExtension
 }
 
 type watcher struct {
@@ -430,7 +431,7 @@ func (w *watcher) compileLoop(ctx context.Context) error {
 		if w.boardPath != "" {
 			boardPath = strings.Split(w.boardPath, string(os.PathSeparator))
 		}
-		svg, _, err := compile(ctx, w.ms, w.plugins, &fs, w.layout, w.renderOpts, w.fontFamily, w.animateInterval, w.inputPath, w.outputPath, boardPath, false, w.bundle, w.forceAppendix, w.pw.Page)
+		svg, _, err := compile(ctx, w.ms, w.plugins, &fs, w.layout, w.renderOpts, w.fontFamily, w.animateInterval, w.inputPath, w.outputPath, boardPath, false, w.bundle, w.forceAppendix, w.pw.Page, w.outputFormat)
 		w.boardpathMu.Unlock()
 		errs := ""
 		if err != nil {


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

**Add --format flag to enable PNG output to stdout, allowing users to pipe D2 diagram output in PNG format to other tools.**

Changes:
- Add format flag support for PNG output to stdout
- Add test cases for format flag handling
- Update getOutputFormat to handle format flags properly

Example usage:
```
d2 input.d2 --stdout-format png -
```
Test: ./make.sh test

<img width="918" alt="image" src="https://github.com/user-attachments/assets/ebcd34aa-2e18-4b2b-90ab-c113b15927dd" />