### PR TITLE
d2cli: --no-xml-tag

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -7,6 +7,7 @@
 - `d2 fmt` now supports a `--check` flag [#2253](https://github.com/terrastruct/d2/pull/2253)
 - CLI: PNG output to stdout is supported using `--stdout-format png -` [#2291](https://github.com/terrastruct/d2/pull/2291)
 - Globs: `&connected` and `&leaf` filters are implemented [#2299](https://github.com/terrastruct/d2/pull/2299)
+- CLI: add --no-xml-tag for direct HTML embedding [#2302](https://github.com/terrastruct/d2/pull/2302)
 
 #### Improvements 🧹
 

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -151,6 +151,9 @@ Lists available themes
 .Ns .
 .It Ar fmt Ar file.d2 ...
 Format all passed files
+.It Fl -no-xml-tag Ar false
+Omit XML tag (<?xml ...?>) from output SVG files. Useful when generating SVGs for direct HTML embedding
+.Ns .
 .Ns .
 .El
 .Sh ENVIRONMENT VARIABLES
@@ -202,6 +205,8 @@ See -p[ort] flag.
 See --browser flag.
 .It Ev Sy D2_STDOUT_FORMAT
 See --stdout-format flag.
+.It Ev Sy D2_NO_XML_TAG
+See --no-xml-tag flag.
 .El
 .Sh SEE ALSO
 .Xr d2plugin-tala 1

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -129,6 +129,11 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		return err
 	}
 
+	noXMLTagFlag, err := ms.Opts.Bool("D2_NO_XML_TAG", "no-xml-tag", "", false, "suppress the XML declaration in SVG output")
+	if err != nil {
+		return err
+	}
+
 	plugins, err := d2plugin.ListPlugins(ctx)
 	if err != nil {
 		return err
@@ -318,6 +323,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		ThemeID:     themeFlag,
 		DarkThemeID: darkThemeFlag,
 		Scale:       scale,
+		NoXMLTag:    noXMLTagFlag,
 	}
 
 	if *watchFlag {
@@ -868,6 +874,7 @@ func _render(ctx context.Context, ms *xmain.State, plugin d2plugin.Plugin, opts 
 		DarkThemeID:        opts.DarkThemeID,
 		ThemeOverrides:     opts.ThemeOverrides,
 		DarkThemeOverrides: opts.DarkThemeOverrides,
+		NoXMLTag:           opts.NoXMLTag,
 		Scale:              scale,
 	})
 	if err != nil {

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -129,7 +129,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 		return err
 	}
 
-	noXMLTagFlag, err := ms.Opts.Bool("D2_NO_XML_TAG", "no-xml-tag", "", false, "suppress the XML declaration in SVG output")
+	noXMLTagFlag, err := ms.Opts.Bool("D2_NO_XML_TAG", "no-xml-tag", "", false, "omit XML tag (<?xml ...?>) from output SVG files. Useful when generating SVGs for direct HTML embedding")
 	if err != nil {
 		return err
 	}

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -86,6 +86,7 @@ type RenderOpts struct {
 	// MasterID is passed when the diagram should use something other than its own hash for unique targeting
 	// Currently, that's when multi-boards are collapsed
 	MasterID string
+	NoXMLTag *bool
 }
 
 func dimensions(diagram *d2target.Diagram, pad int) (left, top, width, height int) {
@@ -2117,7 +2118,9 @@ func Render(diagram *d2target.Diagram, opts *RenderOpts) ([]byte, error) {
 			w, h,
 			dimensions,
 		)
-		xmlTag = `<?xml version="1.0" encoding="utf-8"?>`
+		if opts.NoXMLTag == nil || !*opts.NoXMLTag {
+			xmlTag = `<?xml version="1.0" encoding="utf-8"?>`
+		}
 		fitToScreenWrapperClosing = "</svg>"
 		idAttr = `id="d2-svg"`
 		tag = "svg"

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -983,6 +983,29 @@ layers: {
 			},
 		},
 		{
+			name: "no_xml_tag",
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "test.d2", `x -> y`)
+				err := runTestMain(t, ctx, dir, env, "--no-xml-tag", "test.d2", "no-xml.svg")
+				assert.Success(t, err)
+				noXMLSvg := readFile(t, dir, "no-xml.svg")
+				assert.False(t, strings.Contains(string(noXMLSvg), "<?xml"))
+
+				writeFile(t, dir, "test.d2", `x -> y`)
+				err = runTestMain(t, ctx, dir, env, "test.d2", "with-xml.svg")
+				assert.Success(t, err)
+				withXMLSvg := readFile(t, dir, "with-xml.svg")
+				assert.True(t, strings.Contains(string(withXMLSvg), "<?xml"))
+
+				env.Setenv("D2_NO_XML_TAG", "1")
+				writeFile(t, dir, "test.d2", `x -> y`)
+				err = runTestMain(t, ctx, dir, env, "test.d2", "no-xml-env.svg")
+				assert.Success(t, err)
+				noXMLEnvSvg := readFile(t, dir, "no-xml-env.svg")
+				assert.False(t, strings.Contains(string(noXMLEnvSvg), "<?xml"))
+			},
+		},
+		{
 			name: "basic-fmt",
 			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
 				writeFile(t, dir, "hello-world.d2", `x ---> y`)


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

for https://github.com/terrastruct/d2/issues/2273

When outputting SVGs for HTML, you don't want the <xml> tag, which is not valid in HTML