### PR TITLE
add nil pointer check

### DIFF
--- a/d2cli/export.go
+++ b/d2cli/export.go
@@ -24,7 +24,7 @@ var STDOUT_FORMAT_MAP = map[string]exportExtension{
 var SUPPORTED_STDOUT_FORMATS = []string{"png", "svg"}
 
 func getOutputFormat(stdoutFormatFlag *string, outputPath string) (exportExtension, error) {
-	if *stdoutFormatFlag != "" {
+	if stdoutFormatFlag != nil && *stdoutFormatFlag != "" {
 		format := strings.ToLower(*stdoutFormatFlag)
 		if ext, ok := STDOUT_FORMAT_MAP[format]; ok {
 			return ext, nil


### PR DESCRIPTION
This pull request includes a small but important change to the `d2cli/export.go` file to handle a potential nil pointer dereference. The change ensures that the `stdoutFormatFlag` is checked for nil before dereferencing it.

* [`d2cli/export.go`](diffhunk://#diff-f588c767dfb97498969dc23064f877a228828fc086d77598633451057f703d10L27-R27): Added a nil check for `stdoutFormatFlag` before dereferencing it in the `getOutputFormat` function.