### PR TITLE
refactor: replace ioutil with os and io packages for file operations

### DIFF
--- a/d2chaos/d2chaos_test.go
+++ b/d2chaos/d2chaos_test.go
@@ -3,7 +3,6 @@ package d2chaos_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -90,14 +89,14 @@ func TestD2Chaos(t *testing.T) {
 
 func test(t *testing.T, textPath, text string) {
 	t.Logf("writing d2 to %v (%d bytes)", textPath, len(text))
-	err := ioutil.WriteFile(textPath, []byte(text), 0644)
+	err := os.WriteFile(textPath, []byte(text), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	goencText := fmt.Sprintf("%#v", text)
 	t.Logf("writing d2.goenc to %v (%d bytes)", textPath+".goenc", len(goencText))
-	err = ioutil.WriteFile(textPath+".goenc", []byte(goencText), 0644)
+	err = os.WriteFile(textPath+".goenc", []byte(goencText), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/d2cli/help.go
+++ b/d2cli/help.go
@@ -55,7 +55,7 @@ func layoutCmd(ctx context.Context, ms *xmain.State, ps []d2plugin.Plugin) error
 	}
 }
 
-func themesCmd(ctx context.Context, ms *xmain.State) {
+func themesCmd(_ context.Context, ms *xmain.State) {
 	fmt.Fprintf(ms.Stdout, "Available themes:\n%s", d2themescatalog.CLIString())
 }
 

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 	"github.com/fsnotify/fsnotify"
-	"nhooyr.io/websocket"
-	"nhooyr.io/websocket/wsjson"
 
 	"oss.terrastruct.com/util-go/xbrowser"
 

--- a/d2renderers/d2svg/dark_theme/dark_theme_test.go
+++ b/d2renderers/d2svg/dark_theme/dark_theme_test.go
@@ -3,7 +3,6 @@ package dark_theme_test
 import (
 	"context"
 	"encoding/xml"
-	"io/ioutil"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -449,7 +448,7 @@ func run(t *testing.T, tc testCase) {
 	assert.Success(t, err)
 	err = os.MkdirAll(dataPath, 0755)
 	assert.Success(t, err)
-	err = ioutil.WriteFile(pathGotSVG, svgBytes, 0600)
+	err = os.WriteFile(pathGotSVG, svgBytes, 0600)
 	assert.Success(t, err)
 	defer os.Remove(pathGotSVG)
 

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 
 	"oss.terrastruct.com/util-go/assert"
 	"oss.terrastruct.com/util-go/diff"

--- a/e2etests/report/main.go
+++ b/e2etests/report/main.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	stdlog "log"
 	"os"
 	"os/exec"
@@ -104,7 +103,7 @@ func main() {
 			return err
 		}
 		if info.IsDir() {
-			files, err := ioutil.ReadDir(path)
+			files, err := os.ReadDir(path)
 			if err != nil {
 				panic(err)
 			}
@@ -112,7 +111,7 @@ func main() {
 			var testFile os.FileInfo
 			for _, f := range files {
 				if strings.HasSuffix(f.Name(), "exp.svg") {
-					testFile = f
+					testFile, _ = f.Info()
 					break
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.0
 require (
 	github.com/PuerkitoBio/goquery v1.10.0
 	github.com/alecthomas/chroma/v2 v2.14.0
+	github.com/coder/websocket v1.8.12
 	github.com/dop251/goja v0.0.0-20240927123429-241b342198c2
 	github.com/dsoprea/go-exif/v3 v3.0.1
 	github.com/dsoprea/go-png-image-structure/v2 v2.0.0-20210512210324-29b889a6093d
@@ -28,7 +29,6 @@ require (
 	golang.org/x/tools v0.25.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 	gonum.org/v1/plot v0.14.0
-	nhooyr.io/websocket v1.8.17
 	oss.terrastruct.com/util-go v0.0.0-20241005222610-44c011a04896
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -203,8 +205,6 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
-nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=
 oss.terrastruct.com/util-go v0.0.0-20241005222610-44c011a04896 h1:g752s1ECv9FD8GunFOZRGWzjeR0cr/TZdSsjAnFEmL8=
 oss.terrastruct.com/util-go v0.0.0-20241005222610-44c011a04896/go.mod h1:eMWv0sOtD9T2RUl90DLWfuShZCYp4NrsqNpI8eqO6U4=
 rsc.io/pdf v0.1.1 h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=

--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -212,7 +212,7 @@ func httpGet(ctx context.Context, href string) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("expected status 200 but got %d %s", resp.StatusCode, resp.Status)
 	}
 	r := http.MaxBytesReader(nil, resp.Body, maxImageSize)
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve code consistency and update dependencies. The most important changes include replacing deprecated `ioutil` package functions with their counterparts in the `os` and `io` packages, updating import paths for the `websocket` package, and updating the `go.mod` file to reflect these changes.

### Code consistency improvements:

* [`d2chaos/d2chaos_test.go`](diffhunk://#diff-80c02cc56505c7ba69f1cd469442a09c2e10b691c5131aedd69a78cd2910e71dL93-R99): Replaced `ioutil.WriteFile` with `os.WriteFile` to write files in the `test` function.
* [`d2renderers/d2svg/dark_theme/dark_theme_test.go`](diffhunk://#diff-b8727691f6779bb6d13d8af4bcb59a0f873dea28784447d97431561490a4b5eaL452-R451): Replaced `ioutil.WriteFile` with `os.WriteFile` to write SVG files in the `run` function.
* [`e2etests/report/main.go`](diffhunk://#diff-df6a7aeadd5fc027f9d01cd65d1e488f90880610e07ff7d66757648dcad5c3e4L107-R114): Replaced `ioutil.ReadDir` with `os.ReadDir` and updated file info retrieval in the `main` function.
* [`lib/imgbundler/imgbundler.go`](diffhunk://#diff-cb4412993a6372039375420477b1813ebd9e0bbfb6c9efc486df75f165d739f0L215-R215): Replaced `ioutil.ReadAll` with `io.ReadAll` to read HTTP responses in the `httpGet` function.

### Dependency updates:

* `d2cli/watch.go`, `e2etests-cli/main_test.go`: Updated import paths for the `websocket` package from `nhooyr.io/websocket` to `github.com/coder/websocket`. [[1]](diffhunk://#diff-fc70cf71bc274a18a06914bfd17d043d0cdc7795896c3f1abf9597d0340c0ef5R20-L22) [[2]](diffhunk://#diff-dd19faf5f0671aedc3466a87d8d59637a2ef3019460668a306c15a233bf5c9a7L16-R16)
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R10): Added `github.com/coder/websocket` and removed `nhooyr.io/websocket` to reflect the updated import paths. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R10) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L31)

### Minor improvements:

* [`d2cli/help.go`](diffhunk://#diff-cbd0e56d37ae76cfba24e495fff9005203c21c805cc08128aeb22a511dd25aa9L58-R58): Updated the `themesCmd` function to use an unnamed context parameter.
