### PR TITLE
compiler: support center in d2-config

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -6,4 +6,6 @@
 
 #### Bugfixes ⛑️
 
-- Compiler: fixes panic when `sql_shape` shape value had mixed casing [#2349](https://github.com/terrastruct/d2/pull/2349)
+- Compiler:
+  - fixes panic when `sql_shape` shape value had mixed casing [#2349](https://github.com/terrastruct/d2/pull/2349)
+  - fixes support for `center` in `d2-config` [#2360](https://github.com/terrastruct/d2/pull/2360)

--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -1455,6 +1455,12 @@ func compileConfig(ir *d2ir.Map) (*d2target.Config, error) {
 		config.LayoutEngine = go2.Pointer(f.Primary().Value.ScalarString())
 	}
 
+	f = configMap.GetField(d2ast.FlatUnquotedString("center"))
+	if f != nil {
+		val, _ := strconv.ParseBool(f.Primary().Value.ScalarString())
+		config.Center = &val
+	}
+
 	f = configMap.GetField(d2ast.FlatUnquotedString("theme-overrides"))
 	if f != nil {
 		overrides, err := compileThemeOverrides(f.Map())


### PR DESCRIPTION
This PR fixes support for `center` in `d2-config` variables. Looks like it was only partially implemented but should be supported per [documentation](https://d2lang.com/tour/vars/#configuration-variables).

Test file:

```d2
vars: {
  d2-config: {
    center: true
  }
}

x -> y
```

before change:

`preserveAspectRatio="xMinYMin meet"`

after change:

`preserveAspectRatio="xMidYMid meet"`