### PR TITLE
d2oracle: fix delete underscore linked

### DIFF
--- a/d2ir/compile.go
+++ b/d2ir/compile.go
@@ -1070,11 +1070,6 @@ func (c *compiler) compileLink(f *Field, refctx *RefContext) {
 		return
 	}
 
-	if linkIDA[0].ScalarString() == "root" && linkIDA[0].IsUnquoted() {
-		c.errorf(refctx.Key.Key, "cannot refer to root in link")
-		return
-	}
-
 	if !linkIDA[0].IsUnquoted() {
 		return
 	}

--- a/d2oracle/edit_test.go
+++ b/d2oracle/edit_test.go
@@ -6118,6 +6118,28 @@ c -> d
 `,
 		},
 		{
+			name: "underscore_linked",
+			text: `k
+
+layers: {
+  x: {
+    a
+    b: {link: _}
+  }
+}
+`,
+			key:       `b`,
+			boardPath: []string{"x"},
+			exp: `k
+
+layers: {
+  x: {
+    a
+  }
+}
+`,
+		},
+		{
 			name: "underscore_no_conflict",
 
 			text: `x: {

--- a/testdata/d2oracle/TestDelete/underscore_linked.exp.json
+++ b/testdata/d2oracle/TestDelete/underscore_linked.exp.json
@@ -1,0 +1,292 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,0:0:0-7:0:32",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,0:0:0-0:1:1",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "k",
+                        "raw_string": "k"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {}
+          }
+        },
+        {
+          "map_key": {
+            "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,2:0:3-6:1:31",
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,2:0:3-2:6:9",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,2:0:3-2:6:9",
+                    "value": [
+                      {
+                        "string": "layers",
+                        "raw_string": "layers"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,2:8:11-6:1:31",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,3:2:15-5:3:29",
+                      "key": {
+                        "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,3:2:15-3:3:16",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,3:2:15-3:3:16",
+                              "value": [
+                                {
+                                  "string": "x",
+                                  "raw_string": "x"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "map": {
+                          "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,3:5:18-5:3:29",
+                          "nodes": [
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,4:4:24-4:5:25",
+                                "key": {
+                                  "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,4:4:24-4:5:25",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,4:4:24-4:5:25",
+                                        "value": [
+                                          {
+                                            "string": "a",
+                                            "raw_string": "a"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {}
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "k",
+        "id_val": "k",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "k",
+                        "raw_string": "k"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "attributes": {
+          "label": {
+            "value": "k"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "near_key": null,
+          "shape": {
+            "value": "rectangle"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ],
+    "layers": [
+      {
+        "name": "x",
+        "isFolderOnly": false,
+        "ast": {
+          "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,0:0:0-1:0:0",
+          "nodes": [
+            {
+              "map_key": {
+                "range": ",0:0:0-0:0:0",
+                "key": {
+                  "range": ",0:0:0-0:0:0",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,4:4:24-4:5:25",
+                        "value": [
+                          {
+                            "string": "a",
+                            "raw_string": "a"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "primary": {},
+                "value": {}
+              }
+            }
+          ]
+        },
+        "root": {
+          "id": "",
+          "id_val": "",
+          "attributes": {
+            "label": {
+              "value": ""
+            },
+            "labelDimensions": {
+              "width": 0,
+              "height": 0
+            },
+            "style": {},
+            "near_key": null,
+            "shape": {
+              "value": ""
+            },
+            "direction": {
+              "value": ""
+            },
+            "constraint": null
+          },
+          "zIndex": 0
+        },
+        "edges": null,
+        "objects": [
+          {
+            "id": "a",
+            "id_val": "a",
+            "references": [
+              {
+                "key": {
+                  "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,4:4:24-4:5:25",
+                  "path": [
+                    {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2oracle/TestDelete/underscore_linked.d2,4:4:24-4:5:25",
+                        "value": [
+                          {
+                            "string": "a",
+                            "raw_string": "a"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "key_path_index": 0,
+                "map_key_edge_index": -1
+              }
+            ],
+            "attributes": {
+              "label": {
+                "value": "a"
+              },
+              "labelDimensions": {
+                "width": 0,
+                "height": 0
+              },
+              "style": {},
+              "near_key": null,
+              "shape": {
+                "value": "rectangle"
+              },
+              "direction": {
+                "value": ""
+              },
+              "constraint": null
+            },
+            "zIndex": 0
+          }
+        ]
+      }
+    ]
+  },
+  "err": "<nil>"
+}


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

first pass: replaces layer's link with "root..."
second pass: can't compile with root.

just remove the check, not doing much anyway