### PR TITLE
imagebundler: treat octet streams with svg signature as svg mimetypes

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -9,3 +9,4 @@
 - Compiler:
   - fixes panic when `sql_shape` shape value had mixed casing [#2349](https://github.com/terrastruct/d2/pull/2349)
   - fixes support for `center` in `d2-config` [#2360](https://github.com/terrastruct/d2/pull/2360)
+- CLI: fetch and render remote images of mimetype octet-stream correctly [#2370](https://github.com/terrastruct/d2/pull/2370)

--- a/lib/imgbundler/imgbundler.go
+++ b/lib/imgbundler/imgbundler.go
@@ -166,7 +166,7 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 	var err error
 	if isRemote {
 		l.Debug(fmt.Sprintf("fetching %s remotely", string(href)))
-		buf, mimeType, err = httpGet(ctx, html.UnescapeString(string(href)))
+		buf, mimeType, err = httpGet(ctx, l, html.UnescapeString(string(href)))
 	} else {
 		l.Debug(fmt.Sprintf("reading %s from disk", string(href)))
 		path := html.UnescapeString(string(href))
@@ -181,8 +181,15 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 
 	if mimeType == "" {
 		mimeType = sniffMimeType(href, buf, isRemote)
+		l.Debug(fmt.Sprintf("no mimetype provided - sniffed MIME type for %s: %s", string(href), mimeType))
+	} else {
+		l.Debug(fmt.Sprintf("mimetype provided for %s: %s", string(href), mimeType))
 	}
 	mimeType = strings.Replace(mimeType, "text/xml", "image/svg+xml", 1)
+	if mimeType == "application/octet-stream" && bytes.Contains(buf, []byte("<svg")) {
+		l.Debug(fmt.Sprintf("octet-stream mimetype replaced with svg for %s", string(href)))
+		mimeType = "image/svg+xml"
+	}
 	b64 := base64.StdEncoding.EncodeToString(buf)
 
 	out := []byte(fmt.Sprintf(`<image href="data:%s;base64,%s"`, mimeType, b64))
@@ -194,7 +201,7 @@ func worker(ctx context.Context, l simplelog.Logger, inputPath string, href []by
 
 var httpClient = &http.Client{}
 
-func httpGet(ctx context.Context, href string) ([]byte, string, error) {
+func httpGet(ctx context.Context, l simplelog.Logger, href string) ([]byte, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
@@ -208,6 +215,7 @@ func httpGet(ctx context.Context, href string) ([]byte, string, error) {
 		return nil, "", err
 	}
 	defer resp.Body.Close()
+	l.Debug(fmt.Sprintf("fetched %s remotely - response code %v", string(href), resp.StatusCode))
 	if resp.StatusCode != 200 {
 		return nil, "", fmt.Errorf("expected status 200 but got %d %s", resp.StatusCode, resp.Status)
 	}
@@ -216,7 +224,10 @@ func httpGet(ctx context.Context, href string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	return buf, resp.Header.Get("Content-Type"), nil
+	contentType := resp.Header.Get("Content-Type")
+	l.Debug(fmt.Sprintf("fetched content type: %s, Content length: %d bytes", contentType, len(buf)))
+
+	return buf, contentType, nil
 }
 
 // sniffMimeType sniffs the mime type of href based on its file extension and contents.


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

closes https://github.com/terrastruct/d2/issues/2367