### PR TITLE
d2js: support unicode characters

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -27,4 +27,4 @@
   - fixes panic when comment lines appear in arrays [#2378](https://github.com/terrastruct/d2/pull/2378)
   - fixes inconsistencies when objects were double quoted [#2390](https://github.com/terrastruct/d2/pull/2390)
 - CLI: fetch and render remote images of mimetype octet-stream correctly [#2370](https://github.com/terrastruct/d2/pull/2370)
-- d2js: handle unicode characters (PR pending)
+- d2js: handle unicode characters [#2393](https://github.com/terrastruct/d2/pull/2393)

--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -27,3 +27,4 @@
   - fixes panic when comment lines appear in arrays [#2378](https://github.com/terrastruct/d2/pull/2378)
   - fixes inconsistencies when objects were double quoted [#2390](https://github.com/terrastruct/d2/pull/2390)
 - CLI: fetch and render remote images of mimetype octet-stream correctly [#2370](https://github.com/terrastruct/d2/pull/2370)
+- d2js: handle unicode characters (PR pending)

--- a/d2js/js/src/worker.browser.js
+++ b/d2js/js/src/worker.browser.js
@@ -54,7 +54,10 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = await d2.render(JSON.stringify(data));
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: atob(response.data) });
+          const decoded = new TextDecoder().decode(
+            Uint8Array.from(atob(response.data), (c) => c.charCodeAt(0))
+          );
+          currentPort.postMessage({ type: "result", data: decoded });
         } catch (err) {
           currentPort.postMessage({ type: "error", error: err.message });
         }

--- a/d2js/js/src/worker.node.js
+++ b/d2js/js/src/worker.node.js
@@ -49,7 +49,10 @@ export function setupMessageHandler(isNode, port, initWasm) {
           const result = await d2.render(JSON.stringify(data));
           const response = JSON.parse(result);
           if (response.error) throw new Error(response.error.message);
-          currentPort.postMessage({ type: "result", data: atob(response.data) });
+          const decoded = new TextDecoder().decode(
+            Uint8Array.from(atob(response.data), (c) => c.charCodeAt(0))
+          );
+          currentPort.postMessage({ type: "result", data: decoded });
         } catch (err) {
           currentPort.postMessage({ type: "error", error: err.message });
         }

--- a/d2js/js/test/unit/basic.test.js
+++ b/d2js/js/test/unit/basic.test.js
@@ -171,6 +171,17 @@ layers: {
     await d2.worker.terminate();
   }, 20000);
 
+  test("unicode characters work", async () => {
+    const d2 = new D2();
+    const result = await d2.compile("こんにちは -> ♒️");
+    const svg = await d2.render(result.diagram);
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+    expect(svg).toContain("こんにちは");
+    expect(svg).toContain("♒️");
+    await d2.worker.terminate();
+  }, 20000);
+
   test("handles syntax errors correctly", async () => {
     const d2 = new D2();
     try {


### PR DESCRIPTION
fixes unicode support for d2js

closes #2386 (contains screenshot of current behaviour)

Basically `btoa()` doesn't support unicode as detailed [here on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings) so the unicode characters aren't decoded properly when the processing the response

I followed the approach suggested by MDN and have added in a test as well

working in browser version:

<img width="956" alt="Screenshot" src="https://github.com/user-attachments/assets/e0b974bd-92e7-43ee-ba4f-c70c6be8651f" />