### PR TITLE
d2parser: impose max key length

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -15,6 +15,8 @@
     - Watch mode ignores backup files (e.g. files created by certain editors like Helix). [#2131](https://github.com/terrastruct/d2/issues/2131)
 - Compiler:
     - `link`s can be set to root path, e.g. `/xyz`. [#2357](https://github.com/terrastruct/d2/issues/2357)
+- Parser:
+    - impose max key length. It's almost certainly a mistake if an ID gets too long, e.g. missing quotes [#2465](https://github.com/terrastruct/d2/pull/2465)
 - Render:
     - horizontal padding added for connection labels [#2461](https://github.com/terrastruct/d2/pull/2461)
 

--- a/d2parser/parse.go
+++ b/d2parser/parse.go
@@ -984,6 +984,14 @@ func (p *parser) parseKey() (k *d2ast.KeyPath) {
 			k = nil
 		} else {
 			k.Range.End = k.Path[len(k.Path)-1].Unbox().GetRange().End
+			for _, part := range k.Path {
+				if part.Unbox() != nil {
+					if len(part.Unbox().ScalarString()) > 518 {
+						p.errorf(k.Range.Start, k.Range.End, "key length %d exceeds maximum allowed length of 518", len(part.Unbox().ScalarString()))
+						break
+					}
+				}
+			}
 		}
 	}()
 

--- a/d2parser/parse_test.go
+++ b/d2parser/parse_test.go
@@ -500,6 +500,15 @@ func testImport(t *testing.T) {
 				assert.ErrorString(t, err, "d2/testdata/d2parser/TestParse/import/#09.d2:1:7: unquoted strings cannot begin with ...@ as that's import spread syntax")
 			},
 		},
+		{
+			text: `gcloud: {
+  icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAABORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAABORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAA
+}
+`,
+			assert: func(t testing.TB, ast *d2ast.Map, err error) {
+				assert.ErrorString(t, err, "d2/testdata/d2parser/TestParse/import/#10.d2:2:24: key length 555 exceeds maximum allowed length of 518")
+			},
+		},
 	}
 
 	runa(t, tca)

--- a/testdata/d2parser/TestParse/import/#10.exp.json
+++ b/testdata/d2parser/TestParse/import/#10.exp.json
@@ -1,0 +1,100 @@
+{
+  "ast": {
+    "range": "d2/testdata/d2parser/TestParse/import/#10.d2,0:0:0-3:0:591",
+    "nodes": [
+      {
+        "map_key": {
+          "range": "d2/testdata/d2parser/TestParse/import/#10.d2,0:0:0-2:1:590",
+          "key": {
+            "range": "d2/testdata/d2parser/TestParse/import/#10.d2,0:0:0-0:6:6",
+            "path": [
+              {
+                "unquoted_string": {
+                  "range": "d2/testdata/d2parser/TestParse/import/#10.d2,0:0:0-0:6:6",
+                  "value": [
+                    {
+                      "string": "gcloud",
+                      "raw_string": "gcloud"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "primary": {},
+          "value": {
+            "map": {
+              "range": "d2/testdata/d2parser/TestParse/import/#10.d2,0:8:8-2:1:590",
+              "nodes": [
+                {
+                  "map_key": {
+                    "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:2:12-1:22:32",
+                    "key": {
+                      "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:2:12-1:6:16",
+                      "path": [
+                        {
+                          "unquoted_string": {
+                            "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:2:12-1:6:16",
+                            "value": [
+                              {
+                                "string": "icon",
+                                "raw_string": "icon"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "primary": {},
+                    "value": {
+                      "unquoted_string": {
+                        "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:8:18-1:22:32",
+                        "value": [
+                          {
+                            "string": "data:image/png",
+                            "raw_string": "data:image/png"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "map_key": {
+                    "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:23:33-1:578:588",
+                    "key": {
+                      "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:23:33-1:578:588",
+                      "path": [
+                        {
+                          "unquoted_string": {
+                            "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:23:33-1:578:588",
+                            "value": [
+                              {
+                                "string": "base64,iVBORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAABORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAABORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAA",
+                                "raw_string": "base64,iVBORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAABORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAABORw0KGgoAAAANSUhEUgAAAMwAAADACAMAAAB/Pny7AAAAjVBMVEVChfT///89fOM3gPTk7P0+g/R0oPaKr+0rc+E0d+I5euNYjObt9P1lmiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAAiVBORw0KGgoAAAANSUhEUgAAA"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "primary": {},
+                    "value": {}
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "err": {
+    "errs": [
+      {
+        "range": "d2/testdata/d2parser/TestParse/import/#10.d2,1:23:33-1:578:588",
+        "errmsg": "d2/testdata/d2parser/TestParse/import/#10.d2:2:24: key length 555 exceeds maximum allowed length of 518"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

it's almost certainly a mistake if an ID gets too long. e.g. trying to set base64 without quotes