### PR TITLE
validate gradient color stops

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -21,6 +21,7 @@
 - Compiler:
     - `link`s can be set to root path, e.g. `/xyz`. [#2357](https://github.com/terrastruct/d2/issues/2357)
     - When importing a file, attempt resolving substitutions at the imported file scope first [#2482](https://github.com/terrastruct/d2/pull/2482)
+    - validate gradient color stops. [#2492](https://github.com/terrastruct/d2/pull/2492)
 - Parser:
     - impose max key length. It's almost certainly a mistake if an ID gets too long, e.g. missing quotes [#2465](https://github.com/terrastruct/d2/pull/2465)
 - Render:

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -3929,6 +3929,14 @@ svc_1.t2 -> b: do with B
 				tassert.Equal(t, "d2/testdata/d2compiler/TestCompile/meow.d2", g.Layers[0].Layers[0].AST.Range.Path)
 			},
 		},
+		{
+			name: "invalid_gradient_color_stop",
+			text: `
+				x
+				x.style.fill: "linear-gradient(#ggg, #000)"
+			`,
+			expErr: `d2/testdata/d2compiler/TestCompile/invalid_gradient_color_stop.d2:3:19: expected "fill" to be a valid named color ("orange"), a hex code ("#f0ff3a"), or a gradient ("linear-gradient(red, blue)")`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/lib/color/color.go
+++ b/lib/color/color.go
@@ -512,19 +512,18 @@ var NamedColors = []string{
 var ColorHexRegex = regexp.MustCompile(`^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$`)
 
 func ValidColor(color string) bool {
-
 	if IsGradient(color) {
 		gradient, err := ParseGradient(color)
+		if err != nil {
+			return false
+		}
 		for _, colorStop := range gradient.ColorStops {
 			_, err = csscolorparser.Parse(colorStop.Color)
 			if err != nil {
-				break
+				return false
 			}
 		}
-		return err == nil
-	}
-
-	if !go2.Contains(NamedColors, strings.ToLower(color)) && !ColorHexRegex.MatchString(color) {
+	} else if !go2.Contains(NamedColors, strings.ToLower(color)) && !ColorHexRegex.MatchString(color) {
 		return false
 	}
 

--- a/lib/color/color.go
+++ b/lib/color/color.go
@@ -512,7 +512,19 @@ var NamedColors = []string{
 var ColorHexRegex = regexp.MustCompile(`^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$`)
 
 func ValidColor(color string) bool {
-	if !go2.Contains(NamedColors, strings.ToLower(color)) && !ColorHexRegex.MatchString(color) && !IsGradient(color) {
+
+	if IsGradient(color) {
+		gradient, err := ParseGradient(color)
+		for _, colorStop := range gradient.ColorStops {
+			_, err = csscolorparser.Parse(colorStop.Color)
+			if err != nil {
+				break
+			}
+		}
+		return err == nil
+	}
+
+	if !go2.Contains(NamedColors, strings.ToLower(color)) && !ColorHexRegex.MatchString(color) {
 		return false
 	}
 

--- a/lib/color/gradient.go
+++ b/lib/color/gradient.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/mazznoer/csscolorparser"
 )
 
 type Gradient struct {
@@ -243,15 +241,10 @@ func UniqueGradientID(cssGradient string) string {
 	return "grad-" + hash
 }
 
+var GradientRegex = regexp.MustCompile(`^(linear|radial)-gradient\((.+)\)$`)
+
 func IsGradient(color string) bool {
-	gradient, err := ParseGradient(color)
-	for _, colorStop := range gradient.ColorStops {
-		_, err = csscolorparser.Parse(colorStop.Color)
-		if err != nil {
-			break
-		}
-	}
-	return err == nil
+	return GradientRegex.MatchString(color)
 }
 
 var URLGradientID = regexp.MustCompile(`^url\('#grad-[a-f0-9]{40}'\)$`)

--- a/lib/color/gradient.go
+++ b/lib/color/gradient.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/mazznoer/csscolorparser"
 )
 
 type Gradient struct {
@@ -241,10 +243,15 @@ func UniqueGradientID(cssGradient string) string {
 	return "grad-" + hash
 }
 
-var GradientRegex = regexp.MustCompile(`^(linear|radial)-gradient\((.+)\)$`)
-
 func IsGradient(color string) bool {
-	return GradientRegex.MatchString(color)
+	gradient, err := ParseGradient(color)
+	for _, colorStop := range gradient.ColorStops {
+		_, err = csscolorparser.Parse(colorStop.Color)
+		if err != nil {
+			break
+		}
+	}
+	return err == nil
 }
 
 var URLGradientID = regexp.MustCompile(`^url\('#grad-[a-f0-9]{40}'\)$`)

--- a/testdata/d2compiler/TestCompile/invalid_gradient_color_stop.exp.json
+++ b/testdata/d2compiler/TestCompile/invalid_gradient_color_stop.exp.json
@@ -1,0 +1,11 @@
+{
+  "graph": null,
+  "err": {
+    "errs": [
+      {
+        "range": "d2/testdata/d2compiler/TestCompile/invalid_gradient_color_stop.d2,2:18:25-2:47:54",
+        "errmsg": "d2/testdata/d2compiler/TestCompile/invalid_gradient_color_stop.d2:3:19: expected \"fill\" to be a valid named color (\"orange\"), a hex code (\"#f0ff3a\"), or a gradient (\"linear-gradient(red, blue)\")"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Currently, D2 does not validate gradient color stops, it just renders black color in case the gradient colors are invalid.
This PR adds the functionality to validate each color stop & in case it's invalid, it throws an error.

As per D2 website `fill` & `stroke` supports css color names & hex colors apart from gradients, however inside gradient D2 supports all color formats (e.g rgb, hsl, etc), hence I used `csscolorparser` library instead of checking against `NamedColors` & `ColorHexRegex`.

`fill` docs: https://d2lang.com/tour/style#fill

/fixes #2490