### PR TITLE
feat: add d2 pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,9 @@
+- id: d2
+  name: d2
+  description: Compiles and renders d2 files
+  entry: sh -ec 'for f in "${@}"; do d2 --omit-version "${f}"; done' --
+  language: golang
+  files: \.d2$
 - id: d2-fmt
   name: d2 fmt
   description: Format d2 files


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

#1528 added the `d2-fmt` hook, and with the addition of #2479, a pre-commit hook can now yield the same output as the prebuilt binaries. Without `--omit-version`, the version is slightly different: `data-d2-version="v0.7.0-HEAD"`. The end-user can always override the `entry` attribute to specify the flags as they prefer

Can be tested with:

```
pre-commit try-repo --all-files --ref=feat/d2-pre-commit-hook https://github.com/maxbrunet/d2 d2
```