### PR TITLE
Allow custom fonts to override HandDrawn font in sketch mode

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -13,6 +13,7 @@
 - labels on scenario/step boards can be set with primary value (like layers) [#2579](https://github.com/terrastruct/d2/pull/2579)
 - autoformatter preserves order of boards [#2580](https://github.com/terrastruct/d2/pull/2580)
 - rename "Legend" with a title/label of your choosing (especially useful for non-English diagrams) [#2582](https://github.com/terrastruct/d2/pull/2582)
+- sketch mode fonts will use custom fonts if provided [#2582](https://github.com/terrastruct/d2/pull/2591)
 
 #### Bugfixes ⛑️
 

--- a/d2lib/d2.go
+++ b/d2lib/d2.go
@@ -218,7 +218,7 @@ func applyDefaults(compileOpts *CompileOptions, renderOpts *d2svg.RenderOpts) {
 	if renderOpts.Sketch == nil {
 		renderOpts.Sketch = go2.Pointer(false)
 	}
-	if *renderOpts.Sketch {
+	if *renderOpts.Sketch && compileOpts.FontFamily == nil {
 		compileOpts.FontFamily = go2.Pointer(d2fonts.HandDrawn)
 	}
 	if renderOpts.Pad == nil {


### PR DESCRIPTION
<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->

closes https://github.com/terrastruct/d2/issues/1684
closes https://github.com/terrastruct/d2/issues/1460