### PR TITLE
[Svg] Enable tooltip on connections

### DIFF
--- a/ci/release/changelogs/next.md
+++ b/ci/release/changelogs/next.md
@@ -8,6 +8,7 @@
   - empty left columns are cropped [#2626](https://github.com/terrastruct/d2/pull/2626)
 - exports:
   - Chromium download through CLI for PNG exports is prompted [#2655](https://github.com/terrastruct/d2/pull/2655)
+  - Svg export now supports adding tooltips on connections
 
 #### Bugfixes ⛑️
 

--- a/d2renderers/d2svg/d2svg.go
+++ b/d2renderers/d2svg/d2svg.go
@@ -1302,6 +1302,11 @@ func drawConnection(writer io.Writer, diagramHash string, connection d2target.Co
 	if connection.DstLabel != nil && connection.DstLabel.Label != "" {
 		fmt.Fprint(writer, renderArrowheadLabel(connection, connection.DstLabel.Label, true, inlineTheme))
 	}
+	if connection.Tooltip != "" {
+		fmt.Fprintf(writer, `<title>%s</title>`,
+			svg.EscapeText(connection.Tooltip),
+		)
+	}
 	fmt.Fprintf(writer, `</g>`)
 	return
 }


### PR DESCRIPTION

<img width="215" height="195" alt="image" src="https://github.com/user-attachments/assets/b5e07aaa-3311-4a14-ab92-dc4907be8922" />


If tests are needed, please point me to best place to add them, ideally with existing similar example.