### PR TITLE
compiler: Preserve matching sql table column types

### DIFF
--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -1061,7 +1061,7 @@ func (c *compiler) compileSQLTable(obj *d2graph.Object) {
 	obj.SQLTable = &d2target.SQLTable{}
 	for _, col := range obj.ChildrenArray {
 		typ := col.Label.Value
-		if typ == col.IDVal {
+		if typ == col.IDVal && !hasExplicitScalarLabel(col.Label.MapKey) {
 			// Not great, AST should easily allow specifying alternate primary field
 			// as an explicit label should change the name.
 			typ = ""
@@ -1084,6 +1084,17 @@ func (c *compiler) compileSQLTable(obj *d2graph.Object) {
 	}
 	obj.Children = nil
 	obj.ChildrenArray = nil
+}
+
+func hasExplicitScalarLabel(mapKey *d2ast.Key) bool {
+	if mapKey == nil {
+		return false
+	}
+	if mapKey.Primary.Unbox() != nil {
+		return true
+	}
+	_, ok := mapKey.Value.Unbox().(d2ast.Scalar)
+	return ok
 }
 
 func (c *compiler) validateKeys(obj *d2graph.Object, m *d2ir.Map) {

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -2744,6 +2744,24 @@ ok: {
 			},
 		},
 		{
+			name: "sql-column-type-matches-name",
+			text: `x: {
+  shape: sql_table
+  date: date
+  id
+  created {constraint: primary_key}
+}`,
+			assertions: func(t *testing.T, g *d2graph.Graph) {
+				table := g.Objects[0].SQLTable
+				tassert.Equal(t, "date", table.Columns[0].Name.Label)
+				tassert.Equal(t, "date", table.Columns[0].Type.Label)
+				tassert.Equal(t, "id", table.Columns[1].Name.Label)
+				tassert.Empty(t, table.Columns[1].Type.Label)
+				tassert.Equal(t, "created", table.Columns[2].Name.Label)
+				tassert.Empty(t, table.Columns[2].Type.Label)
+			},
+		},
+		{
 			name: "sql-null-constraint",
 			text: `x: {
   shape: sql_table

--- a/testdata/d2compiler/TestCompile/sql-column-type-matches-name.exp.json
+++ b/testdata/d2compiler/TestCompile/sql-column-type-matches-name.exp.json
@@ -1,0 +1,355 @@
+{
+  "graph": {
+    "name": "",
+    "isFolderOnly": false,
+    "ast": {
+      "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,0:0:0-5:1:79",
+      "nodes": [
+        {
+          "map_key": {
+            "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,0:0:0-5:1:79",
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "primary": {},
+            "value": {
+              "map": {
+                "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,0:3:3-5:1:79",
+                "nodes": [
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,1:2:7-1:18:23",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,1:2:7-1:7:12",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,1:2:7-1:7:12",
+                              "value": [
+                                {
+                                  "string": "shape",
+                                  "raw_string": "shape"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,1:9:14-1:18:23",
+                          "value": [
+                            {
+                              "string": "sql_table",
+                              "raw_string": "sql_table"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,2:2:26-2:12:36",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,2:2:26-2:6:30",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,2:2:26-2:6:30",
+                              "value": [
+                                {
+                                  "string": "date",
+                                  "raw_string": "date"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "unquoted_string": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,2:8:32-2:12:36",
+                          "value": [
+                            {
+                              "string": "date",
+                              "raw_string": "date"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,3:2:39-3:4:41",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,3:2:39-3:4:41",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,3:2:39-3:4:41",
+                              "value": [
+                                {
+                                  "string": "id",
+                                  "raw_string": "id"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {}
+                    }
+                  },
+                  {
+                    "map_key": {
+                      "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:2:44-4:35:77",
+                      "key": {
+                        "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:2:44-4:9:51",
+                        "path": [
+                          {
+                            "unquoted_string": {
+                              "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:2:44-4:9:51",
+                              "value": [
+                                {
+                                  "string": "created",
+                                  "raw_string": "created"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "primary": {},
+                      "value": {
+                        "map": {
+                          "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:10:52-4:35:77",
+                          "nodes": [
+                            {
+                              "map_key": {
+                                "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:11:53-4:34:76",
+                                "key": {
+                                  "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:11:53-4:21:63",
+                                  "path": [
+                                    {
+                                      "unquoted_string": {
+                                        "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:11:53-4:21:63",
+                                        "value": [
+                                          {
+                                            "string": "constraint",
+                                            "raw_string": "constraint"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                },
+                                "primary": {},
+                                "value": {
+                                  "unquoted_string": {
+                                    "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,4:23:65-4:34:76",
+                                    "value": [
+                                      {
+                                        "string": "primary_key",
+                                        "raw_string": "primary_key"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "root": {
+      "id": "",
+      "id_val": "",
+      "attributes": {
+        "label": {
+          "value": ""
+        },
+        "labelDimensions": {
+          "width": 0,
+          "height": 0
+        },
+        "style": {},
+        "iconStyle": {},
+        "near_key": null,
+        "shape": {
+          "value": ""
+        },
+        "direction": {
+          "value": ""
+        },
+        "constraint": null
+      },
+      "zIndex": 0
+    },
+    "edges": null,
+    "objects": [
+      {
+        "id": "x",
+        "id_val": "x",
+        "references": [
+          {
+            "key": {
+              "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,0:0:0-0:1:1",
+              "path": [
+                {
+                  "unquoted_string": {
+                    "range": "d2/testdata/d2compiler/TestCompile/sql-column-type-matches-name.d2,0:0:0-0:1:1",
+                    "value": [
+                      {
+                        "string": "x",
+                        "raw_string": "x"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "key_path_index": 0,
+            "map_key_edge_index": -1
+          }
+        ],
+        "sql_table": {
+          "columns": [
+            {
+              "name": {
+                "label": "date",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "type": {
+                "label": "date",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "constraint": null,
+              "reference": ""
+            },
+            {
+              "name": {
+                "label": "id",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "type": {
+                "label": "",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "constraint": null,
+              "reference": ""
+            },
+            {
+              "name": {
+                "label": "created",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "type": {
+                "label": "",
+                "fontSize": 0,
+                "fontFamily": "",
+                "language": "",
+                "color": "",
+                "italic": false,
+                "bold": false,
+                "underline": false,
+                "labelWidth": 0,
+                "labelHeight": 0
+              },
+              "constraint": [
+                "primary_key"
+              ],
+              "reference": ""
+            }
+          ]
+        },
+        "attributes": {
+          "label": {
+            "value": "x"
+          },
+          "labelDimensions": {
+            "width": 0,
+            "height": 0
+          },
+          "style": {},
+          "iconStyle": {},
+          "near_key": null,
+          "shape": {
+            "value": "sql_table"
+          },
+          "direction": {
+            "value": ""
+          },
+          "constraint": null
+        },
+        "zIndex": 0
+      }
+    ]
+  },
+  "err": null
+}


### PR DESCRIPTION
## Summary

Fixes #1960.

SQL table columns with an explicit type label equal to the column key, such as `date: date`, were compiled as if the type were implicit and ended up with an empty rendered type. This keeps matching explicit scalar labels while preserving empty types for implicit columns like `id` and map-only columns like `created {constraint: primary_key}`.

## Changes

- Only blank matching SQL column types when the column has no explicit scalar label.
- Add a compiler regression test covering `date: date`, an implicit `id`, and a constraint-only column.

## Testing

- `go test ./d2compiler -run TestCompile/sql-column-type-matches-name -count=1` failed before the fix with `expected: "date"`, `actual: ""`.
- `TESTDATA_ACCEPT=1 GOTOOLCHAIN=go1.25.0 go test ./d2compiler -run TestCompile/sql-column-type-matches-name -count=1`
- `GOTOOLCHAIN=go1.25.0 go test ./d2compiler -run TestCompile/sql-column-type-matches-name -count=1`
- `GOTOOLCHAIN=go1.25.0 go test ./e2etests -run TestE2E/stable/sql_table_tooltip_animated -count=1`
- `GOTOOLCHAIN=go1.25.0 go test ./d2compiler -run 'TestCompile/sql' -count=1`
- `GOTOOLCHAIN=go1.25.0 go test ./d2compiler -count=1`
- `git diff --check`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.
