### PR TITLE
fix: normalize config layout engine casing

### DIFF
--- a/d2compiler/compile.go
+++ b/d2compiler/compile.go
@@ -1538,7 +1538,7 @@ func compileConfig(ir *d2ir.Map) (*d2target.Config, error) {
 
 	f = configMap.GetField(d2ast.FlatUnquotedString("layout-engine"))
 	if f != nil {
-		config.LayoutEngine = go2.Pointer(f.Primary().Value.ScalarString())
+		config.LayoutEngine = go2.Pointer(strings.ToLower(f.Primary().Value.ScalarString()))
 	}
 
 	f = configMap.GetField(d2ast.FlatUnquotedString("center"))

--- a/d2compiler/compile_test.go
+++ b/d2compiler/compile_test.go
@@ -5327,6 +5327,22 @@ x -> y
 				},
 			},
 			{
+				name: "layout-engine-case-insensitive",
+				run: func(t *testing.T) {
+					_, config, err := d2compiler.Compile("d2/testdata/d2compiler/TestCompile2/vars/config/layout-engine-case-insensitive.d2", strings.NewReader(`
+vars: {
+	d2-config: {
+    layout-engine: ELK
+  }
+}
+
+x -> y
+`), nil)
+					assert.Success(t, err)
+					assert.Equal(t, "elk", *config.LayoutEngine)
+				},
+			},
+			{
 				name: "invalid",
 				run: func(t *testing.T) {
 					assertCompile(t, `


### PR DESCRIPTION
Fixes #2414.

## Summary
- normalize `vars.d2-config.layout-engine` values to lowercase when compiling config
- add coverage for uppercase `ELK` in config vars

## Tests
- `go test ./d2compiler -run 'TestCompile2/vars/config/layout-engine-case-insensitive'`
- `go test ./d2compiler -run 'TestCompile2/vars/config'`
- `go test ./d2compiler ./d2lib`
