### PR TITLE
cli: add --watch-cleanup to remove output file on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ d2 --watch in.d2 out.svg
 ```
 
 A browser window will open with `out.svg` and live-reload on changes to `in.d2`.
+If you want the generated output removed on exit, use `d2 --watch --watch-cleanup in.d2 out.svg`.
 
 ## Install
 

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -75,6 +75,10 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	if err != nil {
 		return err
 	}
+	watchCleanupFlag, err := ms.Opts.Bool("D2_WATCH_CLEANUP", "watch-cleanup", "", false, "when used with watch, remove generated output files when exiting")
+	if err != nil {
+		return err
+	}
 	layoutFlag := ms.Opts.String("D2_LAYOUT", "layout", "l", "dagre", `the layout engine used`)
 	themeFlag, err := ms.Opts.Int64("D2_THEME", "theme", "t", 0, "the diagram theme ID")
 	if err != nil {
@@ -369,6 +373,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 			port:            *portFlag,
 			inputPath:       inputPath,
 			outputPath:      outputPath,
+			cleanupOutput:   *watchCleanupFlag,
 			bundle:          *bundleFlag,
 			forceAppendix:   *forceAppendixFlag,
 			pw:              pw,

--- a/d2cli/watch.go
+++ b/d2cli/watch.go
@@ -51,6 +51,7 @@ type watcherOpts struct {
 	port            string
 	inputPath       string
 	outputPath      string
+	cleanupOutput   bool
 	boardPath       string
 	pwd             string
 	bundle          bool
@@ -88,6 +89,8 @@ type watcher struct {
 
 	resMu sync.Mutex
 	res   *compileResult
+
+	cleanupOutputDir bool
 }
 
 type compileResult struct {
@@ -118,6 +121,13 @@ func newWatcher(ctx context.Context, ms *xmain.State, opts watcherOpts) (*watche
 }
 
 func (w *watcher) init() error {
+	if w.cleanupOutput && w.outputPath != "-" {
+		outputDir := watchOutputDir(w.outputPath)
+		if outputDir != "" {
+			_, err := os.Stat(outputDir)
+			w.cleanupOutputDir = errors.Is(err, os.ErrNotExist)
+		}
+	}
 	fw, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err
@@ -151,20 +161,35 @@ func (w *watcher) initStaticFileServer() error {
 	return nil
 }
 
-func (w *watcher) run() error {
-	defer w.close()
+func (w *watcher) run() (err error) {
+	defer func() {
+		w.close()
+		if !w.cleanupOutput || w.outputPath == "-" {
+			return
+		}
+		cleanupErr := cleanupWatchOutput(w.outputPath, w.cleanupOutputDir)
+		if cleanupErr == nil {
+			return
+		}
+		if err == nil {
+			err = cleanupErr
+			return
+		}
+		w.ms.Log.Warn.Printf("failed to clean up watch output %s: %v", w.ms.HumanPath(w.outputPath), cleanupErr)
+	}()
 
 	w.goFunc(w.watchLoop)
 	w.goFunc(w.compileLoop)
 
-	err := w.goServe()
+	err = w.goServe()
 	if err != nil {
 		return err
 	}
 
 	w.wg.Wait()
 	w.close()
-	return w.err
+	err = w.err
+	return err
 }
 
 func (w *watcher) close() {
@@ -485,7 +510,33 @@ func (w *watcher) listen() error {
 	}
 	w.l = l
 	w.ms.Log.Success.Printf("listening on http://%v", w.l.Addr())
+	if w.cleanupOutput {
+		w.ms.Log.Info.Printf("press Ctrl-C to quit and remove %s", w.ms.HumanPath(w.outputPath))
+	} else {
+		w.ms.Log.Info.Printf("press Ctrl-C to quit")
+	}
 	return nil
+}
+
+func cleanupWatchOutput(outputPath string, removeDir bool) error {
+	err := os.Remove(outputPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	outputDir := watchOutputDir(outputPath)
+	if !removeDir || outputDir == "" {
+		return nil
+	}
+	return os.RemoveAll(outputDir)
+}
+
+func watchOutputDir(outputPath string) string {
+	ext := filepath.Ext(outputPath)
+	if ext == "" {
+		return ""
+	}
+	return strings.TrimSuffix(outputPath, ext)
 }
 
 func (w *watcher) goServe() error {

--- a/e2etests-cli/main_test.go
+++ b/e2etests-cli/main_test.go
@@ -1343,6 +1343,52 @@ layers: {
 			},
 		},
 		{
+			name:   "watch-cleanup",
+			serial: true,
+			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {
+				writeFile(t, dir, "index.d2", `a -> b`)
+
+				stderr := &stderrWrapper{}
+				tms := testMain(dir, env, "--watch", "--watch-cleanup", "--browser=0", "index.d2", "out.svg")
+				tms.Stderr = stderr
+
+				tms.Start(t, ctx)
+				interrupted := false
+				defer func() {
+					if interrupted {
+						return
+					}
+					err := tms.Signal(ctx, os.Interrupt)
+					assert.Success(t, err)
+				}()
+
+				doneRE := regexp.MustCompile(`successfully compiled index.d2`)
+				_, err := waitLogs(ctx, stderr, doneRE)
+				assert.Success(t, err)
+
+				outputPath := filepath.Join(dir, "out.svg")
+				_, err = os.Stat(outputPath)
+				assert.Success(t, err)
+
+				err = tms.Signal(ctx, os.Interrupt)
+				assert.Success(t, err)
+				interrupted = true
+
+				deadline := time.Now().Add(2 * time.Second)
+				for {
+					_, err = os.Stat(outputPath)
+					if errors.Is(err, os.ErrNotExist) {
+						break
+					}
+					assert.Success(t, err)
+					if time.Now().After(deadline) {
+						t.Fatalf("expected %s to be removed after watch exit", outputPath)
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			},
+		},
+		{
 			name:   "watch-ok-link",
 			serial: true,
 			run: func(t *testing.T, ctx context.Context, dir string, env *xos.Env) {


### PR DESCRIPTION
# Summary

This PR adds a `--watch-cleanup` flag for `d2 --watch`.

When the flag is enabled, exiting watch mode with `Ctrl-C` removes the generated output file. Without the flag, watch mode keeps the current behavior and leaves the output in place.

Example:

```sh
d2 --watch --watch-cleanup input.d2 out.svg
```

# Motivation

When using `d2 --watch`, the generated `.svg` is often just a temporary preview artifact. Today it remains on disk after watch mode exits, which can leave behind files the user did not intend to keep.

This change makes cleanup explicit and opt-in:

- `d2 --watch ...` keeps the output
- `d2 --watch --watch-cleanup ...` removes the output on exit

# Changes

- add `--watch-cleanup` CLI flag
- wire the flag into watch-mode shutdown
- print a clearer terminal message in watch mode:
  - `press Ctrl-C to quit`
  - `press Ctrl-C to quit and remove ...` when cleanup is enabled
- add an e2e test covering `Ctrl-C` + cleanup behavior
- update the README with a short usage note

# Behavior

## Default behavior

```sh
d2 --watch input.d2 out.svg
```

- watch mode exits on `Ctrl-C`
- `out.svg` remains on disk

## Cleanup behavior

```sh
d2 --watch --watch-cleanup input.d2 out.svg
```

- watch mode exits on `Ctrl-C`
- `out.svg` is removed on exit

# Notes

This is intentionally opt-in so existing workflows do not change.

# Testing

Ran:

```sh
go test ./e2etests-cli -run TestCLI_E2E/watch-cleanup -count=1
go test ./e2etests-cli -run 'TestCLI_E2E/watch-' -count=1
```