### PR TITLE
Fix package installation links

### DIFF
--- a/ci/release/docker/Dockerfile
+++ b/ci/release/docker/Dockerfile
@@ -1,4 +1,4 @@
-# https://hub.docker.com/repository/docker/terrastruct/d2
+# https://hub.docker.com/r/terrastruct/d2
 FROM ubuntu:latest
 
 ARG TARGETARCH

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -222,14 +222,14 @@ scoop install main/d2
 ```
 
 #### Chocolatey
-[![chocolatey/d2_badge](https://img.shields.io/chocolatey/v/d2)]([https://chocolatey.org/](https://community.chocolatey.org/packages/d2/0.6.6))
+[![chocolatey/d2_badge](https://img.shields.io/chocolatey/v/d2)](https://community.chocolatey.org/packages/d2)
 ```sh
 choco install d2
 ```
 
 ## Docker
 
-https://hub.docker.com/repository/docker/terrastruct/d2
+https://hub.docker.com/r/terrastruct/d2
 
 We publish `amd64` and `arm64` images based on `debian:latest` for each release.
 


### PR DESCRIPTION
## What changed

- Fix the malformed Chocolatey badge destination and point it at the current unversioned D2 package page.
- Replace the legacy Docker Hub repository route with the public D2 image page in both installation documentation and the release Dockerfile reference.

## Why

The Chocolatey Markdown had nested links and could not navigate correctly. The legacy Docker Hub route is not the canonical public image URL and can send signed-out users through an authentication redirect.

Package names and installation commands remain unchanged.

## Validation

- `git diff --check`
- Followed both destinations with `curl -L`; each returned HTTP 200.
- Asserted that the legacy and malformed forms are absent and both canonical destinations are present.
