### PR TITLE
Update transferred dependency links

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,8 +1,8 @@
 name: daily
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '42 0 * * *' # daily at 00:42
+  # Scheduled publishing is paused until npm trusted publishing and durable
+  # package ownership are configured. Keep manual dispatch for verification.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ci/sub"]
 	path = ci/sub
-	url = https://github.com/terrastruct/ci
+	url = https://github.com/d2lang/ci

--- a/ci/release/changelogs/v0.2.5.md
+++ b/ci/release/changelogs/v0.2.5.md
@@ -23,6 +23,6 @@ Customizations and layouts take a big leap forward with this release! Put togeth
 
 #### Bugfixes ⛑️
 
-- Fixes `d2` erroring on malformed user paths (`fdopendir` error). [util-go#10](https://github.com/terrastruct/util-go/pull/10)
+- Fixes `d2` erroring on malformed user paths (`fdopendir` error). [util-go#10](https://github.com/d2lang/util-go/pull/10)
 - Arrowhead labels being set without maps wasn't being picked up. [#1015](https://github.com/terrastruct/d2/pull/1015)
 - Fixes a `dagre` layout error with connections to a container shape with a blockstring label. [#1032](https://github.com/terrastruct/d2/pull/1032)

--- a/d2cli/main.go
+++ b/d2cli/main.go
@@ -302,7 +302,7 @@ func Run(ctx context.Context, ms *xmain.State) (err error) {
 	}
 
 	if *darkThemeFlag == -1 {
-		darkThemeFlag = nil // TODO this is a temporary solution: https://github.com/terrastruct/util-go/issues/7
+		darkThemeFlag = nil // TODO this is a temporary solution: https://github.com/d2lang/util-go/issues/7
 	}
 	if darkThemeFlag != nil {
 		match = d2themescatalog.Find(*darkThemeFlag)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ interested in, etc).
 ## CI
 
 Most of D2's CI is open sourced in its own
-[repository](https://github.com/terrastruct/ci), included as a submodule. After you clone
+[repository](https://github.com/d2lang/ci), included as a submodule. After you clone
 D2, make sure you initialize the submodules:
 
 ```sh

--- a/install.sh
+++ b/install.sh
@@ -377,7 +377,7 @@ LIB_FLAG=1
 # interpreted as a single -xyzq flag. The other deficiency is lack of support for short
 # flag syntax like -carg where the arg is not separated from the flag. This one is
 # unfixable I believe unfortunately but for combined short flags I have opened
-# https://github.com/terrastruct/ci/issues/6
+# https://github.com/d2lang/ci/issues/6
 #
 # flag_parse stores state in $FLAG, $FLAGRAW, $FLAGARG and $FLAGSHIFT.
 # FLAG contains the name of the flag without hyphens.


### PR DESCRIPTION
## What changed

- update canonical links from `terrastruct/ci` and `terrastruct/util-go` to their new `d2lang` repository locations
- keep the existing Go vanity module path unchanged
- pause scheduled npm nightlies until durable npm ownership and trusted publishing are configured

## Why

The dependency repositories have moved to the `d2lang` organization. New clones and contributors should use the canonical locations rather than GitHub compatibility redirects.

## Checks

- `git diff --check`
- transferred repository IDs and old-location redirects verified
