### PR TITLE
Add stage-only npm trusted publishing

### DIFF
--- a/.github/workflows/npm-stage.yml
+++ b/.github/workflows/npm-stage.yml
@@ -1,0 +1,66 @@
+name: npm stage
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to stage, or "nightly" for a dated prerelease
+        required: true
+        type: string
+        default: nightly
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-stage
+  cancel-in-progress: false
+
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ./go.mod
+          cache: true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install supported npm
+        run: |
+          npm install --global npm@12.0.2
+          npm --version
+
+      - name: Install binaryen
+        run: |
+          BINARYEN_VERSION="version_123"
+          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar -xz
+          sudo cp "binaryen-${BINARYEN_VERSION}"/bin/* /usr/local/bin/
+          wasm-opt --version
+
+      - name: Build and test package
+        run: |
+          COLOR=1 ./make.sh js
+          cd d2js/js
+          bun test test/unit
+
+      - name: Stage package for review
+        env:
+          NPM_PUBLISH_MODE: stage
+          NPM_VERSION: ${{ inputs.version }}
+        run: COLOR=1 ./make.sh js

--- a/d2js/js/ci/build.sh
+++ b/d2js/js/ci/build.sh
@@ -37,6 +37,7 @@ sh_c bun build.js
 if [ -n "${NPM_VERSION:-}" ]; then
   cp package.json package.json.bak
   trap 'rm -f .npmrc; mv package.json.bak package.json' EXIT
+  PUBLISH_MODE="${NPM_PUBLISH_MODE:-publish}"
 
   if [ "$NPM_VERSION" = "nightly" ]; then
     echo "Publishing nightly version to npm..."
@@ -59,33 +60,50 @@ if [ -n "${NPM_VERSION:-}" ]; then
   # Update package.json with the new version
   npm version "${PUBLISH_VERSION}" --no-git-tag-version
 
-  echo "Publishing to npm with tag '${NPM_TAG}'..."
-  if [ -n "${NPM_TOKEN-}" ]; then
-    # Create .npmrc file with auth token
-    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-
-    if npm publish --tag "$NPM_TAG"; then
-      echo "Successfully published @terrastruct/d2@${PUBLISH_VERSION} to npm with tag '${NPM_TAG}'"
-
-      # For official releases, bump the patch version
-      if [ "$NPM_VERSION" != "nightly" ]; then
-        # Restore original package.json first
-        mv package.json.bak package.json
-
-        echo "Bumping version to ${NPM_VERSION}"
-        npm version "${NPM_VERSION}" --no-git-tag-version
-        git add package.json
-        git commit -m "Bump version to ${NPM_VERSION} [skip ci]"
-
-        # Cancel the trap since we manually restored and don't want it to execute on exit
-        trap - EXIT
+  case "$PUBLISH_MODE" in
+    stage)
+      echo "Staging package on npm with tag '${NPM_TAG}'..."
+      if npm stage publish --tag "$NPM_TAG"; then
+        echo "Successfully staged @terrastruct/d2@${PUBLISH_VERSION} on npm with tag '${NPM_TAG}'"
+      else
+        echoerr "Failed to stage package on npm"
+        exit 1
       fi
-    else
-      echoerr "Failed to publish package to npm"
+      ;;
+    publish)
+      if [ -z "${NPM_TOKEN-}" ]; then
+        echoerr "NPM_TOKEN environment variable is required for direct publishing"
+        exit 1
+      fi
+
+      # Create .npmrc file with auth token
+      echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+
+      echo "Publishing to npm with tag '${NPM_TAG}'..."
+      if npm publish --tag "$NPM_TAG"; then
+        echo "Successfully published @terrastruct/d2@${PUBLISH_VERSION} to npm with tag '${NPM_TAG}'"
+
+        # For official releases, bump the patch version
+        if [ "$NPM_VERSION" != "nightly" ]; then
+          # Restore original package.json first
+          mv package.json.bak package.json
+
+          echo "Bumping version to ${NPM_VERSION}"
+          npm version "${NPM_VERSION}" --no-git-tag-version
+          git add package.json
+          git commit -m "Bump version to ${NPM_VERSION} [skip ci]"
+
+          # Cancel the trap since we manually restored and don't want it to execute on exit
+          trap - EXIT
+        fi
+      else
+        echoerr "Failed to publish package to npm"
+        exit 1
+      fi
+      ;;
+    *)
+      echoerr "Unknown NPM_PUBLISH_MODE: ${PUBLISH_MODE}"
       exit 1
-    fi
-  else
-    echoerr "NPM_TOKEN environment variable is required for publishing to npm"
-    exit 1
-  fi
+      ;;
+  esac
 fi


### PR DESCRIPTION
## What changed

- add a manual GitHub-hosted workflow for staging `@terrastruct/d2` through npm OIDC
- require Node 24, npm 12.0.2, and `id-token: write`
- build and run the JavaScript unit tests before staging
- preserve the existing token-based direct-release path while adding an explicit `stage` mode

## Why

The existing scheduled publisher depended on a long-lived npm token. Staged trusted publishing lets the repository submit a package for review without making it public; a maintainer must approve it separately with 2FA.

## Validation

- `git diff --check`
- `sh -n d2js/js/ci/build.sh`
- workflow YAML parse
- `COLOR=1 ./ci/sub/bin/nofixups.sh`

No package version is published by this pull request.