### PR TITLE
fix d2js CJS asset paths

### DIFF
--- a/d2js/js/build.js
+++ b/d2js/js/build.js
@@ -44,6 +44,11 @@ const commonConfig = {
   minify: true,
 };
 
+const nodeEsmBanner = `import { dirname as __d2Dirname } from "node:path";
+import { fileURLToPath as __d2FileURLToPath } from "node:url";
+const __D2_NODE_MODULE_DIR__ = __d2Dirname(__d2FileURLToPath(import.meta.url));`;
+const nodeCjsBanner = `const __D2_NODE_MODULE_DIR__ = __dirname;`;
+
 async function buildDynamicFiles(platform) {
   const platformContent =
     platform === "node"
@@ -113,6 +118,7 @@ async function buildAndCopy(buildType) {
       format: "esm",
       target: "node",
       platform: "node",
+      banner: nodeEsmBanner,
       entrypoints: [resolve(SRC_DIR, "index.js"), resolve(SRC_DIR, "worker.js")],
     },
     "node-cjs": {
@@ -121,6 +127,7 @@ async function buildAndCopy(buildType) {
       format: "cjs",
       target: "node",
       platform: "node",
+      banner: nodeCjsBanner,
       entrypoints: [resolve(SRC_DIR, "index.js"), resolve(SRC_DIR, "worker.js")],
     },
   };
@@ -154,6 +161,10 @@ async function buildAndCopy(buildType) {
       resolve(ROOT_DIR, "../../d2layouts/d2elklayout/setup.js"),
       join(config.outdir, "setup.js")
     );
+
+    if (buildType === "node-cjs") {
+      await writeFile(join(config.outdir, "package.json"), '{"type":"commonjs"}\n');
+    }
   }
 }
 

--- a/d2js/js/src/platform.node.js
+++ b/d2js/js/src/platform.node.js
@@ -1,11 +1,13 @@
 let nodeModules = null;
 
+// Injected at runtime by the node bundle banners in build.js.
+const moduleDir = __D2_NODE_MODULE_DIR__;
+
 async function loadNodeModules() {
   if (!nodeModules) {
     nodeModules = {
       fs: await import("node:fs/promises"),
       path: await import("node:path"),
-      url: await import("node:url"),
       worker: await import("node:worker_threads"),
     };
   }
@@ -15,15 +17,13 @@ async function loadNodeModules() {
 export async function loadFile(path) {
   const modules = await loadNodeModules();
   const readFile = modules.fs.readFile;
-  const { join, dirname } = modules.path;
-  const { fileURLToPath } = modules.url;
-  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const { join } = modules.path;
 
   try {
-    return await readFile(join(__dirname, path));
+    return await readFile(join(moduleDir, path));
   } catch (err) {
     if (err.code === "ENOENT") {
-      return await readFile(join(__dirname, "../../../wasm", path.replace("./", "")));
+      return await readFile(join(moduleDir, "../../../wasm", path.replace("./", "")));
     }
     throw err;
   }
@@ -32,9 +32,7 @@ export async function loadFile(path) {
 export async function createWorker() {
   const modules = await loadNodeModules();
   const { Worker } = modules.worker;
-  const { join, dirname } = modules.path;
-  const { fileURLToPath } = modules.url;
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const workerPath = join(__dirname, "worker.js");
+  const { join } = modules.path;
+  const workerPath = join(moduleDir, "worker.js");
   return new Worker(workerPath);
 }

--- a/d2js/js/src/worker.node.js
+++ b/d2js/js/src/worker.node.js
@@ -1,7 +1,6 @@
 import { parentPort } from "node:worker_threads";
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 let currentPort;
 let d2;
@@ -14,9 +13,8 @@ function loadScript(content) {
 function loadELK() {
   if (typeof globalThis.ELK === "undefined") {
     try {
-      const __dirname = dirname(fileURLToPath(import.meta.url));
-      const elkJS = readFileSync(join(__dirname, "elk.js"), "utf8");
-      const setupJS = readFileSync(join(__dirname, "setup.js"), "utf8");
+      const elkJS = readFileSync(join(__D2_NODE_MODULE_DIR__, "elk.js"), "utf8");
+      const setupJS = readFileSync(join(__D2_NODE_MODULE_DIR__, "setup.js"), "utf8");
 
       loadScript(elkJS);
       loadScript(setupJS);


### PR DESCRIPTION
## Summary

- define the Node bundle asset directory at bundle runtime instead of allowing Bun to inline the source file URL
- use the runtime directory for WASM, worker, and ELK assets in both ESM and CJS builds
- mark the generated CJS output directory as CommonJS so Node can load the package through its require export
- preserve browser behavior and package layout

## Why

Bun 1.3.14 inlined `import.meta.url` in the CommonJS bundle as the source path. The CJS integration test then looked for `wasm_exec.js` outside `d2js/js`, blocking the stage-only npm workflow before it could test trusted publishing. A packed-package review also found that Node treated the generated CJS `.js` files as ESM because the root package uses `type: module`; the nested marker makes the declared require export work in Node.

## Verification

- `git diff --check`
- formatted source verified by the Linux build
- Linux Bun 1.3.14 run on the banner fix: 32 unit tests passed; CJS and ESM integration both passed
- current Bun 1.3.14 local integration suite: 2 passed, 0 failed
- packed `@terrastruct/d2` tarball installed in an isolated directory; both CommonJS and ESM builds compiled `x -> y` under Node 24
- packed tarball contains `dist/node-cjs/package.json` with the CommonJS marker
- local macOS unit baseline was unchanged at 20 pass / 12 fail; the pre-patch build produced the same result

Nothing is published or staged by this PR.