### PR TITLE
fix npm stage action policy

### DIFF
--- a/.github/workflows/npm-stage.yml
+++ b/.github/workflows/npm-stage.yml
@@ -39,12 +39,11 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Install supported npm
+      - name: Install supported npm and Bun
         run: |
-          npm install --global npm@12.0.2
+          npm install --global npm@12.0.2 bun@1.3.14
           npm --version
+          bun --version
 
       - name: Install binaryen
         run: |


### PR DESCRIPTION
## Summary

- remove the third-party setup-bun action rejected by the repository Actions policy
- install the exact tested Bun 1.3.14 package alongside npm 12.0.2
- keep the workflow limited to GitHub-owned actions

## Verification

- the failed run created zero jobs and npm was never contacted
- repository Actions policy allows GitHub-owned actions only
- workflow now references only actions/checkout, actions/setup-go, and actions/setup-node
- YAML parses and `git diff --check` passes
- npm registry contains exact `bun@1.3.14` and `npm@12.0.2` versions

Nothing was staged or published by the failed run.