### PR TITLE
fix npm stage CI execution

### DIFF
--- a/.github/workflows/npm-stage.yml
+++ b/.github/workflows/npm-stage.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Install binaryen
         run: |
           BINARYEN_VERSION="version_123"
-          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar -xz
-          sudo cp "binaryen-${BINARYEN_VERSION}"/bin/* /usr/local/bin/
+          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar -xz -C "$RUNNER_TEMP"
+          sudo cp "$RUNNER_TEMP/binaryen-${BINARYEN_VERSION}"/bin/* /usr/local/bin/
           wasm-opt --version
 
       - name: Build and test package
         run: |
-          COLOR=1 ./make.sh js
+          CI_FORCE=1 CI_MAKE_ROOT=0 COLOR=1 ./make.sh js
           cd d2js/js
           bun test test/unit
 
@@ -62,4 +62,4 @@ jobs:
         env:
           NPM_PUBLISH_MODE: stage
           NPM_VERSION: ${{ inputs.version }}
-        run: COLOR=1 ./make.sh js
+        run: CI_FORCE=1 CI_MAKE_ROOT=0 COLOR=1 ./make.sh js

--- a/d2js/js/ci/build.sh
+++ b/d2js/js/ci/build.sh
@@ -36,8 +36,13 @@ sh_c bun build.js
 
 if [ -n "${NPM_VERSION:-}" ]; then
   cp package.json package.json.bak
-  trap 'rm -f .npmrc; mv package.json.bak package.json' EXIT
   PUBLISH_MODE="${NPM_PUBLISH_MODE:-publish}"
+  if [ "$PUBLISH_MODE" = stage ] && [ -f package-lock.json ]; then
+    cp package-lock.json package-lock.json.stage.bak
+    trap 'rm -f .npmrc; mv package.json.bak package.json; mv package-lock.json.stage.bak package-lock.json' EXIT
+  else
+    trap 'rm -f .npmrc; mv package.json.bak package.json' EXIT
+  fi
 
   if [ "$NPM_VERSION" = "nightly" ]; then
     echo "Publishing nightly version to npm..."


### PR DESCRIPTION
## Summary
- force the full JS build/test path during manual staging while suppressing protected-branch notifications
- extract Binaryen outside the checkout
- restore the npm lockfile after a staged version is prepared

## Validation
- `sh -n d2js/js/ci/build.sh`
- workflow YAML parses successfully
- `git diff --check`
- npm 12 fixture confirms both package files are restored after the stage cleanup trap
- independent review confirmed `CI_FORCE=1 CI_MAKE_ROOT=0` runs nested d2js CI and preserves real failure exit codes

Local full build was not run because Go is not installed in this worktree environment; GitHub checks provide the Linux validation.