### PR TITLE
avoid pathological wasm optimization

### DIFF
--- a/.github/workflows/npm-stage.yml
+++ b/.github/workflows/npm-stage.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   stage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/d2js/js/ci/build.sh
+++ b/d2js/js/ci/build.sh
@@ -15,7 +15,9 @@ if [ -n "${NPM_VERSION:-}" ]; then
   # Optimize with wasm-opt if available
   if command -v wasm-opt >/dev/null 2>&1; then
     echo "Optimizing WASM with wasm-opt..."
-    sh_c "wasm-opt -Oz --enable-bulk-memory-opt main.wasm -o main.wasm"
+    # -Oz can use quadratic memory on large Go WASM modules.
+    # https://github.com/WebAssembly/binaryen/issues/7644
+    sh_c "wasm-opt -O2 --enable-bulk-memory-opt main.wasm -o main.wasm"
   else
     echo "wasm-opt not found, skipping optimization (install with: brew install binaryen)"
   fi


### PR DESCRIPTION
## Summary
- use Binaryen `-O2` instead of `-Oz` for the large Go WASM package
- cap the manual npm staging job at 30 minutes

## Why
The stage-only run spent more than 26 minutes inside `wasm-opt -Oz` without reaching npm. An exact local reproduction remained CPU-active with about 2.36 GiB RSS and rising after 4m54s, with no output file. This matches WebAssembly/binaryen#7644: `-O3`/`-Os`/`-Oz` can have quadratic memory growth on large Go WASM modules, and the maintainer recommends `-O2`. D2 currently includes the same goldmark code implicated by that issue.

No staged npm artifact was created before the run was cancelled.

## Validation
- `sh -n d2js/js/ci/build.sh`
- workflow YAML parses successfully
- `git diff --check`
- exact Binaryen 123 `-O2 --enable-bulk-memory-opt` benchmark completed in 14.83s with ~1.11 GiB peak RSS
- output validated successfully with Binaryen and was 432,564 bytes smaller (1.746%) than the input