### PR TITLE
Remove legacy npm nightly token workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,59 +1,13 @@
 name: daily
 on:
   workflow_dispatch:
-  # Scheduled publishing is paused until npm trusted publishing and durable
-  # package ownership are configured. Keep manual dispatch for verification.
+  # Keep daily CI available for manual verification while scheduled runs are paused.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
-  npm-nightly:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # Needed for git history and version tags
-
-      - name: Check for changes
-        id: check_changes
-        run: |
-          if [ $(git rev-list --count --since="24 hours ago" HEAD) -gt 0 ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "Found changes in the last 24 hours, proceeding to publish d2js nightly"
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No changes in the last 24 hours, skipping d2js nightly publish"
-          fi
-
-      - uses: actions/setup-go@v4
-        if: steps.check_changes.outputs.has_changes == 'true'
-        with:
-          go-version-file: ./go.mod
-          cache: true
-
-      - name: Install binaryen for wasm-opt
-        if: steps.check_changes.outputs.has_changes == 'true'
-        run: |
-          # Install newer version of binaryen from GitHub releases
-          BINARYEN_VERSION="version_123"
-          curl -L "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar -xz
-          sudo cp binaryen-${BINARYEN_VERSION}/bin/* /usr/local/bin/
-          sudo cp -r binaryen-${BINARYEN_VERSION}/lib/* /usr/local/lib/ || true
-          sudo cp -r binaryen-${BINARYEN_VERSION}/include/* /usr/local/include/ || true
-          wasm-opt --version
-
-      - name: Publish nightly version to NPM
-        if: steps.check_changes.outputs.has_changes == 'true'
-        run: |
-          export NPM_VERSION=nightly
-          COLOR=1 ./make.sh js
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
   ci:
-    needs: [npm-nightly]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What changed

- removed the legacy `npm-nightly` job from the manual daily workflow
- removed the obsolete `ci` dependency on that publishing job
- kept the daily CI workflow available by manual dispatch

## Why

The npm package now uses the separately proven stage-only trusted publisher workflow, and the legacy `NPM_TOKEN` secret has been deleted. Keeping a dormant direct-token publisher would leave a misleading, unusable release path in the repository.

## Impact

Manual daily CI remains available and runs directly. This change does not publish or stage an npm package.

## Validation

- parsed `.github/workflows/daily.yml` with Ruby/Psych
- `git diff --check`
- repository-wide search confirmed no remaining workflow references to `NPM_TOKEN` or `npm-nightly`
