### PR TITLE
fix Docker continuity Playwright bootstrap

### DIFF
--- a/.github/workflows/docker-continuity-test.yml
+++ b/.github/workflows/docker-continuity-test.yml
@@ -80,6 +80,12 @@ jobs:
           ref: ${{ needs.validate.outputs.version }}
           persist-credentials: false
 
+      - name: Check out continuity tooling
+        uses: actions/checkout@v6
+        with:
+          path: .continuity-source
+          persist-credentials: false
+
       - name: Download release archive
         env:
           GH_TOKEN: ${{ github.token }}
@@ -93,6 +99,10 @@ jobs:
             --dir "$RUNNER_TEMP/docker-context"
           tar -tzf "$RUNNER_TEMP/docker-context/$asset" >/dev/null
           cp ci/release/docker/entrypoint.sh "$RUNNER_TEMP/docker-context/entrypoint.sh"
+          bash .continuity-source/ci/release/docker/prepare-continuity-dockerfile.sh \
+            "$VERSION" \
+            ci/release/docker/Dockerfile \
+            "$RUNNER_TEMP/Dockerfile"
 
       - name: Log in to Docker Hub
         env:
@@ -118,7 +128,7 @@ jobs:
             --provenance=true \
             --output "type=image,name=$image,push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file "$metadata" \
-            --file ci/release/docker/Dockerfile \
+            --file "$RUNNER_TEMP/Dockerfile" \
             "$RUNNER_TEMP/docker-context"
 
           digest=$(jq -er '."containerimage.digest"' "$metadata")
@@ -181,6 +191,12 @@ jobs:
           ref: ${{ needs.validate.outputs.version }}
           persist-credentials: false
 
+      - name: Check out continuity tooling
+        uses: actions/checkout@v6
+        with:
+          path: .continuity-source
+          persist-credentials: false
+
       - name: Download release archive
         env:
           GH_TOKEN: ${{ github.token }}
@@ -194,6 +210,10 @@ jobs:
             --dir "$RUNNER_TEMP/docker-context"
           tar -tzf "$RUNNER_TEMP/docker-context/$asset" >/dev/null
           cp ci/release/docker/entrypoint.sh "$RUNNER_TEMP/docker-context/entrypoint.sh"
+          bash .continuity-source/ci/release/docker/prepare-continuity-dockerfile.sh \
+            "$VERSION" \
+            ci/release/docker/Dockerfile \
+            "$RUNNER_TEMP/Dockerfile"
 
       - name: Log in to Docker Hub
         env:
@@ -219,7 +239,7 @@ jobs:
             --provenance=true \
             --output "type=image,name=$image,push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file "$metadata" \
-            --file ci/release/docker/Dockerfile \
+            --file "$RUNNER_TEMP/Dockerfile" \
             "$RUNNER_TEMP/docker-context"
 
           digest=$(jq -er '."containerimage.digest"' "$metadata")

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -46,6 +46,13 @@ must name a published, non-draft GitHub release with both Linux archives; `v0.7.
 default continuity fixture. Delete the continuity-test tag in Docker Hub after reviewing the
 workflow summary and manifest.
 
+The `v0.7.1` fixture embeds playwright-go v0.4702.0, whose original driver CDN no longer
+serves the required ZIP files. For that fixture only, the workflow reconstructs the same
+Playwright 1.47.2 driver layout from a checksum-pinned official `playwright-core` npm
+tarball and the image's Node runtime. Browser payloads use Playwright's current direct CDN.
+The published D2 archive remains unchanged. Other release versions use their tagged
+Dockerfile without this compatibility step.
+
 This test does not disable or replace the existing release script's Docker publishing path.
 
 ### _build.sh

--- a/ci/release/docker/prepare-continuity-dockerfile.sh
+++ b/ci/release/docker/prepare-continuity-dockerfile.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 VERSION SOURCE_DOCKERFILE OUTPUT_DOCKERFILE" >&2
+  exit 2
+fi
+
+version=$1
+source_dockerfile=$2
+output_dockerfile=$3
+
+if [[ ! -f "$source_dockerfile" ]]; then
+  echo "source Dockerfile does not exist: $source_dockerfile" >&2
+  exit 1
+fi
+
+case "$version" in
+  v0.7.1)
+    # playwright-go v0.4702.0 expects a driver ZIP from the retired
+    # playwright.azureedge.net endpoints. Recreate the same 1.47.2 driver
+    # layout from the immutable official playwright-core npm tarball instead.
+    playwright_version=1.47.2
+    playwright_sha256=4f14eac4a244fada8e072d9932a1f9a4752a161b6726f227223ef33fd5dddbf4
+    ;;
+  *)
+    install -m 0644 "$source_dockerfile" "$output_dockerfile"
+    exit 0
+    ;;
+esac
+
+if [[ $(grep -Fxc 'USER debian:debian' "$source_dockerfile") -ne 1 ]]; then
+  echo "expected exactly one debian USER instruction in $source_dockerfile" >&2
+  exit 1
+fi
+
+awk \
+  -v playwright_version="$playwright_version" \
+  -v playwright_sha256="$playwright_sha256" \
+  '
+    $0 == "USER debian:debian" {
+      print "# Restore the Playwright driver without the retired Playwright CDN."
+      print "ARG PLAYWRIGHT_GO_DRIVER_VERSION=" playwright_version
+      print "ARG PLAYWRIGHT_GO_DRIVER_SHA256=" playwright_sha256
+      print "RUN set -eux; \\"
+      print "  driver_dir=\"/home/debian/.cache/ms-playwright-go/$PLAYWRIGHT_GO_DRIVER_VERSION\"; \\"
+      print "  mkdir -p \"$driver_dir\"; \\"
+      print "  curl -fsSL \"https://registry.npmjs.org/playwright-core/-/playwright-core-$PLAYWRIGHT_GO_DRIVER_VERSION.tgz\" -o /tmp/playwright-core.tgz; \\"
+      print "  echo \"$PLAYWRIGHT_GO_DRIVER_SHA256  /tmp/playwright-core.tgz\" | sha256sum -c -; \\"
+      print "  tar -xzf /tmp/playwright-core.tgz -C \"$driver_dir\"; \\"
+      print "  rm /tmp/playwright-core.tgz; \\"
+      print "  chown -R debian:debian /home/debian/.cache/ms-playwright-go"
+      print "ENV PLAYWRIGHT_NODEJS_PATH=/usr/bin/node"
+      print "ENV PLAYWRIGHT_DOWNLOAD_HOST=https://cdn.playwright.dev"
+      print ""
+    }
+    { print }
+  ' "$source_dockerfile" >"$output_dockerfile"


### PR DESCRIPTION
## Summary
- reconstruct the Playwright 1.47.2 driver for the v0.7.1 continuity fixture from the checksum-pinned official playwright-core npm tarball
- keep using the tagged release Dockerfile and published D2 archive
- document the compatibility step

## Validation
- bash syntax check passed
- actionlint passed
- v0.7.1 generated Dockerfile inspected successfully
- non-v0.7.1 pass-through is byte-identical
- Playwright Chromium and ffmpeg artifacts remain available for linux amd64 and arm64

Production Docker tags remain untouched; the workflow still publishes only continuity-test-<run-id>.