### PR TITLE
fix continuity browser cache ownership

### DIFF
--- a/ci/release/docker/prepare-continuity-dockerfile.sh
+++ b/ci/release/docker/prepare-continuity-dockerfile.sh
@@ -50,7 +50,7 @@ awk \
       print "  echo \"$PLAYWRIGHT_GO_DRIVER_SHA256  /tmp/playwright-core.tgz\" | sha256sum -c -; \\"
       print "  tar -xzf /tmp/playwright-core.tgz -C \"$driver_dir\"; \\"
       print "  rm /tmp/playwright-core.tgz; \\"
-      print "  chown -R debian:debian /home/debian/.cache/ms-playwright-go"
+      print "  chown -R debian:debian /home/debian/.cache"
       print "ENV PLAYWRIGHT_NODEJS_PATH=/usr/bin/node"
       print "ENV PLAYWRIGHT_DOWNLOAD_HOST=https://cdn.playwright.dev"
       print ""


### PR DESCRIPTION
The first protected continuity run reached the checksum-pinned Playwright driver bootstrap, then failed before any image push because root owned /home/debian/.cache and the debian build user could not create the sibling ms-playwright browser cache. Chown the cache root, not only the ms-playwright-go child.

This is a one-line compatibility fix. Production tags remain unreachable. Run 30830387315 is the evidence.