### PR TITLE
Use GitHub Actions token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
 on: [push, pull_request]
+permissions:
+  actions: read
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -15,7 +18,7 @@ jobs:
           cache: true
       - run: COLOR=1 ./make.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       - uses: actions/upload-artifact@v4
         if: always()
@@ -29,7 +32,7 @@ jobs:
       - run: git submodule update --init
       - run: COLOR=1 ./ci/sub/bin/nofixups.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
   signed:
     runs-on: ubuntu-latest
@@ -38,5 +41,5 @@ jobs:
       - run: git submodule update --init
       - run: COLOR=1 ./ci/sub/bin/ensure_signed.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,6 +2,9 @@ name: daily
 on:
   workflow_dispatch:
   # Keep daily CI available for manual verification while scheduled runs are paused.
+permissions:
+  actions: read
+  contents: read
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -17,7 +20,7 @@ jobs:
           cache: true
       - run: COLOR=1 CI_FORCE=1 ./make.sh all race
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary

- replace the long-lived `_GITHUB_TOKEN` repository secret with the per-run `github.token`
- explicitly grant workflows `actions: read` and `contents: read`
- leave Slack/Discord webhook credentials unchanged

The old repository secret should be deleted only after this runs successfully on the protected default branch.

## Validation

- YAML parse
- actionlint (excluding existing old-action-version warnings)
- `git diff --check`
- confirmed no `_GITHUB_TOKEN` references remain in the workflows