### PR TITLE
docs: remove active Terrastruct references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![changelog](https://img.shields.io/badge/changelog-read-blue)](./CHANGELOG.md)
 [![npm version](https://img.shields.io/npm/v/@terrastruct/d2)](https://www.npmjs.com/package/@terrastruct/d2)
 [![discord](https://img.shields.io/discord/1039184639652265985?label=discord)](https://discord.gg/NF6X8K4eDq)
-[![twitter](https://img.shields.io/twitter/follow/terrastruct?style=social)](https://twitter.com/terrastruct)
 [![license](https://img.shields.io/github/license/d2lang/d2?color=9cf)](./LICENSE.txt)
 
 <a href="https://play.d2lang.com">
@@ -161,9 +160,7 @@ improved security but the install script is by no means insecure.
 In addition to being a runnable CLI tool, D2 can also be used to produce diagrams from
 Go programs.
 
-For examples, see [./docs/examples/lib](./docs/examples/lib). This [blog
-post](https://terrastruct.com/blog/post/generate-diagrams-programmatically/) also demos a
-complete, runnable example of using D2 as a library for a real-world use case.
+For examples, see [./docs/examples/lib](./docs/examples/lib).
 
 ## Themes
 
@@ -235,8 +232,6 @@ let us know and we'll be happy to include it here!
 - **VSCode extension**: [https://github.com/d2lang/d2-vscode](https://github.com/d2lang/d2-vscode)
 - **Vim extension**: [https://github.com/d2lang/d2-vim](https://github.com/d2lang/d2-vim)
 - **Obsidian plugin**: [https://github.com/d2lang/d2-obsidian](https://github.com/d2lang/d2-obsidian)
-- **Slack app**: [https://d2lang.com/tour/slack](https://d2lang.com/tour/slack)
-- **Discord plugin**: [https://d2lang.com/tour/discord](https://d2lang.com/tour/discord)
 
 ### Community plugins
 
@@ -276,7 +271,7 @@ let us know and we'll be happy to include it here!
 - **Comparison site**: [https://github.com/terrastruct/text-to-diagram-site](https://github.com/terrastruct/text-to-diagram-site)
 - **Playground**: [https://github.com/d2lang/d2-playground](https://github.com/d2lang/d2-playground)
 - **Language docs**: [https://github.com/d2lang/d2-docs](https://github.com/d2lang/d2-docs)
-- **Hosted icons**: [https://icons.terrastruct.com](https://icons.terrastruct.com)
+- **Hosted icons**: [https://icons.d2lang.com](https://icons.d2lang.com)
 
 ## FAQ
 

--- a/ci/release/template/man/d2.1
+++ b/ci/release/template/man/d2.1
@@ -57,7 +57,7 @@ See more docs, the source code and license at
 .Ns .
 .Pp
 Hosted icons at
-.Lk https://icons.terrastruct.com
+.Lk https://icons.d2lang.com
 .Ns .
 .Pp
 Playground runner at

--- a/d2cli/help.go
+++ b/d2cli/help.go
@@ -44,7 +44,7 @@ Subcommands:
   %[1]s validate file.d2  - Validates file.d2
 
 See more docs and the source code at https://oss.terrastruct.com/d2.
-Hosted icons at https://icons.terrastruct.com.
+Hosted icons at https://icons.d2lang.com.
 Playground runner at https://play.d2lang.com.
 `, filepath.Base(ms.Name), version.Version, ms.Opts.Defaults())
 }

--- a/d2lsp/completion.go
+++ b/d2lsp/completion.go
@@ -429,10 +429,10 @@ func getTooltipCompletions() []CompletionItem {
 func getIconCompletions() []CompletionItem {
 	return []CompletionItem{
 		{
-			Label:      "(URL, e.g. https://icons.terrastruct.com/xyz.svg)",
+			Label:      "(URL, e.g. https://icons.d2lang.com/xyz.svg)",
 			Kind:       KeywordCompletion,
 			Detail:     "icon URL",
-			InsertText: "https://icons.terrastruct.com/essentials%2F073-add.svg",
+			InsertText: "https://icons.d2lang.com/essentials%2F073-add.svg",
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- remove the retired Terrastruct social badge and hosted blog link
- remove obsolete Slack and Discord integration listings
- make icons.d2lang.com canonical in the README, CLI help, LSP completion, and man page

Permanent compatibility identifiers such as oss.terrastruct.com/d2, @terrastruct/d2, and terrastruct/d2 are intentionally unchanged.

## Validation
- go test ./d2cli ./d2lsp
- go vet --composites=false ./d2cli ./d2lsp
- mandoc -T utf8 ci/release/template/man/d2.1
- git diff --check
- verified the canonical icon catalog and completion example return HTTP 200